### PR TITLE
Fix quickstarts pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
       <dependency> 
          <groupId>org.switchyard.components</groupId>
          <artifactId>switchyard-component-bean</artifactId>
-         <version>${project.version</version>
+         <version>${project.version}</version>
       </dependency>
       </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
The top level pom in quickstarts is missing a "}" in the version of components-bean.
