### PR TITLE
SWITCHYARD-145

### DIFF
--- a/m1app/pom.xml
+++ b/m1app/pom.xml
@@ -99,7 +99,7 @@
           <executions>
             <execution>
                 <goals>
-                    <goal>configurator</goal>
+                    <goal>configure</goal>
                 </goals>
             </execution>
           </executions>

--- a/m1app/src/main/resources/META-INF/switchyard.xml
+++ b/m1app/src/main/resources/META-INF/switchyard.xml
@@ -7,7 +7,6 @@
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
             targetNamespace="urn:switchyard-quickstarts:m1app:0.1.0-SNAPSHOT"
             name="m1app">
-
     <sca:composite name="m1app">
         <sca:service name="OrderService" promote="OrderService">
             <soap:binding.soap>


### PR DESCRIPTION
config merge uses project artifactId for composite name instead of inheriting the name in user's config
