### PR TITLE
SWITCHYARD-275

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,4 +76,24 @@
       </dependency>
       </dependencies>
     </dependencyManagement>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.1.1</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <phase>none</phase>
+              <goals>
+               <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
Shut off the maven-source-plugin, which is inherited from switchyard-parent.      Avoids a NullPointerException in the build, which is preventing us from deploying release.
