### PR TITLE
SWITCHYARD-324: Auto-start BPM processes if processActionType property is

### DIFF
--- a/demos/helpdesk/src/test/resources/xml/soap-request.xml
+++ b/demos/helpdesk/src/test/resources/xml/soap-request.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <soap:Envelope
     xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
-    xmlns:bpm="urn:switchyard-component-bpm:process:1.0"
     xmlns:helpdesk="urn:switchyard-quickstart-demo:helpdesk:1.0">
-    <soap:Header>
-        <bpm:processActionType>startProcess</bpm:processActionType>
-    </soap:Header>
     <soap:Body>
         <helpdesk:openTicket>
             <ticket>


### PR DESCRIPTION
SWITCHYARD-324: Auto-start BPM processes if processActionType property is unspecified
https://issues.jboss.org/browse/SWITCHYARD-324
