### PR TITLE
SWITCHYARD-329: Add BPM annotations to mark methods as process action tri

### DIFF
--- a/demos/helpdesk/src/main/java/org/switchyard/quickstarts/demos/helpdesk/HelpDeskServiceProcess.java
+++ b/demos/helpdesk/src/main/java/org/switchyard/quickstarts/demos/helpdesk/HelpDeskServiceProcess.java
@@ -18,14 +18,13 @@
  */
 package org.switchyard.quickstarts.demos.helpdesk;
 
-import org.switchyard.component.bpm.BPM;
-import org.switchyard.component.bpm.jbpm.CommandBasedWSHumanTaskHandler;
+import org.switchyard.component.bpm.Process;
+import org.switchyard.component.bpm.task.jbpm.CommandBasedWSHumanTaskHandler;
 
 /**
  * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
  */
-@BPM(
-    processInterface = HelpDeskService.class,
-    taskHandlers = { CommandBasedWSHumanTaskHandler.class }
-)
-public final class HelpDeskServiceProcess {}
+@Process(
+    value=HelpDeskService.class,
+    taskHandlers={CommandBasedWSHumanTaskHandler.class})
+public interface HelpDeskServiceProcess {}


### PR DESCRIPTION
SWITCHYARD-329: Add BPM annotations to mark methods as process action triggers
https://issues.jboss.org/browse/SWITCHYARD-329
