### PR TITLE
SWITCHYARD-348: Change SwitchYard testing from extension of SwitchYardTes

### DIFF
--- a/camel-binding/src/test/java/org/switchyard/quickstarts/camel/binding/CamelBindingTest.java
+++ b/camel-binding/src/test/java/org/switchyard/quickstarts/camel/binding/CamelBindingTest.java
@@ -4,7 +4,8 @@ import java.io.File;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.switchyard.test.SwitchYardTestCase;
+import org.junit.runner.RunWith;
+import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.test.mixins.CDIMixIn;
 
@@ -27,8 +28,9 @@ import org.switchyard.test.mixins.CDIMixIn;
  * MA  02110-1301, USA.
  */
 
+@RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(config = SwitchYardTestCaseConfig.SWITCHYARD_XML, mixins = CDIMixIn.class)
-public class CamelBindingTest extends SwitchYardTestCase  {
+public class CamelBindingTest {
     
     private static String SOURCE_FILE = "target/test-classes/test.txt";
     private static String DEST_FILE = "target/input/test.txt";

--- a/camel-service/src/test/java/org/switchyard/quickstarts/camel/service/CamelServiceTest.java
+++ b/camel-service/src/test/java/org/switchyard/quickstarts/camel/service/CamelServiceTest.java
@@ -1,7 +1,10 @@
 package org.switchyard.quickstarts.camel.service;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.switchyard.component.camel.config.model.RouteScanner;
-import org.switchyard.test.SwitchYardTestCase;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.test.mixins.CDIMixIn;
 
@@ -24,12 +27,13 @@ import org.switchyard.test.mixins.CDIMixIn;
  * MA  02110-1301, USA.
  */
 
+@RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(
         config = SwitchYardTestCaseConfig.SWITCHYARD_XML,
         mixins = CDIMixIn.class,
         scanners = RouteScanner.class
 )
-public class CamelServiceTest extends SwitchYardTestCase  {
+public class CamelServiceTest {
     
     private static final String TEST_MESSAGE = "\n"
       + "bob: Hello there!\n"
@@ -40,10 +44,11 @@ public class CamelServiceTest extends SwitchYardTestCase  {
       + "bob: Four score and seven years\n"
       + "sally: Actually, any kind of dairy is OK in my book\n";
 
+    @ServiceOperation("JavaDSL.acceptMessage")
+    private Invoker acceptMessage;
+
     @Test
     public void testCamelRoute() {
-        newInvoker("JavaDSL")
-        .operation("acceptMessage")
-        .sendInOnly(TEST_MESSAGE);
+        acceptMessage.sendInOnly(TEST_MESSAGE);
     }
 }

--- a/demos/helpdesk/src/test/java/org/switchyard/quickstarts/demos/helpdesk/HelpDeskTests.java
+++ b/demos/helpdesk/src/test/java/org/switchyard/quickstarts/demos/helpdesk/HelpDeskTests.java
@@ -19,9 +19,10 @@
 package org.switchyard.quickstarts.demos.helpdesk;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.switchyard.component.bean.config.model.BeanSwitchYardScanner;
 import org.switchyard.component.bpm.config.model.BpmSwitchYardScanner;
-import org.switchyard.test.SwitchYardTestCase;
+import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.test.mixins.BPMMixIn;
 import org.switchyard.test.mixins.CDIMixIn;
@@ -31,19 +32,21 @@ import org.switchyard.transform.config.model.TransformSwitchYardScanner;
 /**
  * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
  */
+@RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(
     config = SwitchYardTestCaseConfig.SWITCHYARD_XML,
     scanners = {BeanSwitchYardScanner.class, BpmSwitchYardScanner.class, TransformSwitchYardScanner.class},
     mixins = {BPMMixIn.class, CDIMixIn.class, HTTPMixIn.class}
 )
-public class HelpDeskTests extends SwitchYardTestCase {
+public class HelpDeskTests {
+
+    private BPMMixIn bpm;
+    private HTTPMixIn http;
 
     @Test
     public void testHelpDesk() throws Exception {
-        BPMMixIn bpm = getMixIn(BPMMixIn.class);
         if (bpm.startTaskServer("Developer", "User")) {
             try {
-                HTTPMixIn http = getMixIn(HTTPMixIn.class);
                 http.postResourceAndTestXML("http://localhost:18001/HelpDeskService", "/xml/soap-request.xml", "/xml/soap-response.xml");
                 boolean keepWorking = true;
                 while (keepWorking) {

--- a/demos/orders/src/test/java/org/switchyard/quickstarts/demos/orders/InventoryServiceTest.java
+++ b/demos/orders/src/test/java/org/switchyard/quickstarts/demos/orders/InventoryServiceTest.java
@@ -21,19 +21,25 @@ package org.switchyard.quickstarts.demos.orders;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.switchyard.test.InvocationFaultException;
-import org.switchyard.test.SwitchYardTestCase;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.test.mixins.CDIMixIn;
 
+@RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(mixins = CDIMixIn.class)
-public class InventoryServiceTest extends SwitchYardTestCase {
+public class InventoryServiceTest {
+
+    @ServiceOperation("InventoryService.lookupItem")
+    private Invoker lookupItem;
 
     @Test
     public void testItemLookupExists() throws Exception {
         final String ITEM_ID = "BUTTER";
-        Item item = newInvoker("InventoryService")
-            .operation("lookupItem")
+        Item item = lookupItem
             .sendInOut(ITEM_ID)
             .getContent(Item.class);
 
@@ -46,8 +52,7 @@ public class InventoryServiceTest extends SwitchYardTestCase {
         final String ITEM_ID = "GUNS";
         try {
             // This should generate a fault because the ITEM_ID is not found
-            newInvoker("InventoryService")
-                .operation("lookupItem")
+            lookupItem
                 .sendInOut(ITEM_ID)
                 .getContent(Item.class);
             // Looks like we didn't fault, so fail

--- a/demos/orders/src/test/java/org/switchyard/quickstarts/demos/orders/OrderServiceTest.java
+++ b/demos/orders/src/test/java/org/switchyard/quickstarts/demos/orders/OrderServiceTest.java
@@ -21,12 +21,19 @@ package org.switchyard.quickstarts.demos.orders;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.switchyard.test.SwitchYardTestCase;
+import org.junit.runner.RunWith;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.test.mixins.CDIMixIn;
 
+@RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(mixins = CDIMixIn.class)
-public class OrderServiceTest extends SwitchYardTestCase {
+public class OrderServiceTest {
+
+    @ServiceOperation("OrderService.submitOrder")
+    private Invoker submitOrder;
 
     @Test
     public void testOrderAccepted() throws Exception {
@@ -35,8 +42,7 @@ public class OrderServiceTest extends SwitchYardTestCase {
             .setItemId("BUTTER")
             .setQuantity(100);
         
-        OrderAck testAck = newInvoker("OrderService")
-            .operation("submitOrder")
+        OrderAck testAck = submitOrder
             .sendInOut(testOrder)
             .getContent(OrderAck.class);
 

--- a/demos/orders/src/test/java/org/switchyard/quickstarts/demos/orders/TypeTransformationTest.java
+++ b/demos/orders/src/test/java/org/switchyard/quickstarts/demos/orders/TypeTransformationTest.java
@@ -28,24 +28,29 @@ import junit.framework.Assert;
 import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Test;
-import org.switchyard.test.SwitchYardTestCase;
+import org.junit.runner.RunWith;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.test.mixins.CDIMixIn;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+@RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(mixins = CDIMixIn.class)
-public class TypeTransformationTest extends SwitchYardTestCase {
+public class TypeTransformationTest {
 
-    final String ITEM_ID = "BUTTER";
+    @ServiceOperation("OrderService.submitOrder")
+    private Invoker submitOrder;
+
     final String ORDER_XML = "xml/order.xml";
     final String ORDER_ACK_XML = "xml/orderAck.xml";
 
     @Test
     public void testTransformXMLtoJava() throws Exception {
 
-        OrderAck orderAck = newInvoker("OrderService")
-            .operation("submitOrder")
+        OrderAck orderAck = submitOrder
             .inputType(QName.valueOf("{urn:switchyard-quickstart-demo:orders:1.0}submitOrder"))
             .sendInOut(loadXML(ORDER_XML).getDocumentElement())
             .getContent(OrderAck.class);
@@ -61,8 +66,7 @@ public class TypeTransformationTest extends SwitchYardTestCase {
             .setItemId("BUTTER")
             .setQuantity(100);
 
-        Element result = newInvoker("OrderService")
-            .operation("submitOrder")
+        Element result = submitOrder
             .expectedOutputType(QName.valueOf("{urn:switchyard-quickstart-demo:orders:1.0}submitOrderResponse"))
             .sendInOut(testOrder)
             .getContent(Element.class);

--- a/demos/orders/src/test/java/org/switchyard/quickstarts/demos/orders/WebServiceTest.java
+++ b/demos/orders/src/test/java/org/switchyard/quickstarts/demos/orders/WebServiceTest.java
@@ -20,25 +20,28 @@
 package org.switchyard.quickstarts.demos.orders;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.switchyard.component.bean.config.model.BeanSwitchYardScanner;
-import org.switchyard.test.SwitchYardTestCase;
+import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.test.mixins.CDIMixIn;
 import org.switchyard.test.mixins.HTTPMixIn;
 import org.switchyard.transform.config.model.TransformSwitchYardScanner;
 
+@RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(
         config = SwitchYardTestCaseConfig.SWITCHYARD_XML,
         scanners = {BeanSwitchYardScanner.class, TransformSwitchYardScanner.class},
         mixins = {CDIMixIn.class, HTTPMixIn.class})
-public class WebServiceTest extends SwitchYardTestCase {
+public class WebServiceTest {
+
+    private HTTPMixIn httpMixIn;
 
     @Test
     public void invokeOrderWebService() throws Exception {
         // Use the HttpMixIn to invoke the SOAP binding endpoint with a SOAP input (from the test classpath)
         // and compare the SOAP response to a SOAP response resource (from the test classpath)...
-        getMixIn(HTTPMixIn.class).
-                postResourceAndTestXML("http://localhost:18001/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
+        httpMixIn.postResourceAndTestXML("http://localhost:18001/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
     }
 }
 

--- a/rules-interview/src/test/java/org/switchyard/quickstarts/rules/interview/RulesInterviewTest.java
+++ b/rules-interview/src/test/java/org/switchyard/quickstarts/rules/interview/RulesInterviewTest.java
@@ -19,17 +19,24 @@
 package org.switchyard.quickstarts.rules.interview;
 
 import org.junit.Test;
-import org.switchyard.test.SwitchYardTestCase;
+import org.junit.runner.RunWith;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 
 /**
  * @author David Ward &lt;<a href="mailto:dward@jboss.org">dward@jboss.org</a>&gt; (C) 2011 Red Hat Inc.
  */
+@RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(config = SwitchYardTestCaseConfig.SWITCHYARD_XML)
-public class RulesInterviewTest extends SwitchYardTestCase  {
+public class RulesInterviewTest {
+
+    @ServiceOperation("Interview.verify")
+    private Invoker verify;
 
     @Test
     public void testInterviewRules() {
-        newInvoker("Interview").operation("verify").sendInOnly(new Applicant("David", 39));
+        verify.sendInOnly(new Applicant("David", 39));
     }
 }

--- a/transform-smooks/src/test/java/org/switchyard/quickstarts/transform/smooks/ServiceTransformationTest.java
+++ b/transform-smooks/src/test/java/org/switchyard/quickstarts/transform/smooks/ServiceTransformationTest.java
@@ -24,15 +24,26 @@ import javax.xml.namespace.QName;
 import junit.framework.Assert;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
-import org.switchyard.test.SwitchYardTestCase;
+import org.switchyard.test.SwitchYardTestKit;
 import org.switchyard.test.mixins.CDIMixIn;
 
 /**
  * Test Smooks transformations around a service.
  */
+@RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(config = SwitchYardTestCaseConfig.SWITCHYARD_XML, mixins = CDIMixIn.class)
-public class ServiceTransformationTest extends SwitchYardTestCase {
+public class ServiceTransformationTest {
+
+    @ServiceOperation("OrderService.submitOrder")
+    private Invoker submitOrder;
+
+    private SwitchYardTestKit _testKit;
+
 
     // Message types being transformed
     public static final QName FROM_TYPE =
@@ -46,10 +57,9 @@ public class ServiceTransformationTest extends SwitchYardTestCase {
 
     @Test
     public void testTransformXMLtoJava() throws Exception {
-        OrderAck orderAck = newInvoker("OrderService")
-            .operation("submitOrder")
+        OrderAck orderAck = submitOrder
             .inputType(FROM_TYPE)
-            .sendInOut(readResourceString(ORDER_XML))
+            .sendInOut(_testKit.readResourceString(ORDER_XML))
             .getContent(OrderAck.class);
 
         Assert.assertTrue(orderAck.isAccepted());
@@ -62,12 +72,11 @@ public class ServiceTransformationTest extends SwitchYardTestCase {
             .setItemId("BUTTER")
             .setQuantity(100);
 
-        String result = newInvoker("OrderService")
-            .operation("submitOrder")
+        String result = submitOrder
             .expectedOutputType(TO_TYPE)
             .sendInOut(testOrder)
             .getContent(String.class);
 
-        compareXMLToResource(result, ORDER_ACK_XML);
+        _testKit.compareXMLToResource(result, ORDER_ACK_XML);
     }
 }

--- a/transform-smooks/src/test/java/org/switchyard/quickstarts/transform/smooks/SmooksTransformationTest.java
+++ b/transform-smooks/src/test/java/org/switchyard/quickstarts/transform/smooks/SmooksTransformationTest.java
@@ -20,7 +20,8 @@
 package org.switchyard.quickstarts.transform.smooks;
 
 import org.junit.Test;
-import org.switchyard.test.SwitchYardTestCase;
+import org.junit.runner.RunWith;
+import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.test.mixins.SmooksMixIn;
 
@@ -29,14 +30,16 @@ import org.switchyard.test.mixins.SmooksMixIn;
  *
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
+@RunWith(SwitchYardRunner.class)
 @SwitchYardTestCaseConfig(mixins = SmooksMixIn.class)
-public class SmooksTransformationTest extends SwitchYardTestCase {
+public class SmooksTransformationTest {
+
+    private SmooksMixIn smooksMixIn;
 
     @Test
     public void test_Order_read_write() throws Exception {
         // Use the Smooks TestMixIn to verify that the Order_XML.xml
         // Smooks java binding transform works against the supplied order.xml...
-        SmooksMixIn smooksMixIn = getMixIn(SmooksMixIn.class);
         smooksMixIn.testJavaXMLReadWrite(Order.class, "/smooks/Order_XML.xml", "/xml/order.xml");
     }
 
@@ -44,7 +47,6 @@ public class SmooksTransformationTest extends SwitchYardTestCase {
     public void test_OrderAck_read_write() throws Exception {
         // Use the Smooks TestMixIn to verify that the OrderAck_XML.xml
         // Smooks java binding transform works against the supplied orderAck.xml...
-        SmooksMixIn smooksMixIn = getMixIn(SmooksMixIn.class);
         smooksMixIn.testJavaXMLReadWrite(OrderAck.class, "/smooks/OrderAck_XML.xml", "/xml/orderAck.xml");
     }
 }


### PR DESCRIPTION
SWITCHYARD-348: Change SwitchYard testing from extension of SwitchYardTestCase to using @RunWith(SwitchYardRunner.class)

https://issues.jboss.org/browse/SWITCHYARD-348
