### PR TITLE
SWITCHYARD-356: Use of enum for ResourceType restricts extensibility

### DIFF
--- a/rules-interview/src/main/java/org/switchyard/quickstarts/rules/interview/InterviewRules.java
+++ b/rules-interview/src/main/java/org/switchyard/quickstarts/rules/interview/InterviewRules.java
@@ -18,8 +18,6 @@
  */
 package org.switchyard.quickstarts.rules.interview;
 
-import static org.switchyard.common.io.resource.ResourceType.DRL;
-
 import org.switchyard.common.io.resource.SimpleResource;
 import org.switchyard.component.rules.ExecuteRules;
 import org.switchyard.component.rules.Rules;
@@ -37,7 +35,7 @@ public interface InterviewRules extends Interview {
 
     public static final class InterviewDrl extends SimpleResource {
         public InterviewDrl() {
-            super("/org/switchyard/quickstarts/rules/interview/Interview.drl", DRL);
+            super("/org/switchyard/quickstarts/rules/interview/Interview.drl", "DRL");
         }
     }
 

--- a/rules-interview/src/main/resources/META-INF/switchyard.xml
+++ b/rules-interview/src/main/resources/META-INF/switchyard.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
             xmlns:swyd="urn:switchyard-config:switchyard:1.0"
-            xmlns:bpm="urn:switchyard-component-rules:config:1.0"
+            xmlns:rules="urn:switchyard-component-rules:config:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstart:rules-interview:0.1.0-SNAPSHOT"
+            targetNamespace="urn:switchyard-quickstart:rules-interview:0.2.0-SNAPSHOT"
             name="Interview">
     <sca:composite name="Interview">
         <sca:service name="Interview">

--- a/rules-interview/src/test/java/org/switchyard/quickstarts/rules/interview/RulesInterviewTest.java
+++ b/rules-interview/src/test/java/org/switchyard/quickstarts/rules/interview/RulesInterviewTest.java
@@ -39,4 +39,5 @@ public class RulesInterviewTest {
     public void testInterviewRules() {
         verify.sendInOnly(new Applicant("David", 39));
     }
+
 }


### PR DESCRIPTION
SWITCHYARD-356: Use of enum for ResourceType restricts extensibility
https://issues.jboss.org/browse/SWITCHYARD-356
