### PR TITLE
SWITCHYARD-365: targetNamespace is being ignored by NamedModel.getQName()

### DIFF
--- a/demos/helpdesk/src/main/resources/META-INF/switchyard.xml
+++ b/demos/helpdesk/src/main/resources/META-INF/switchyard.xml
@@ -6,7 +6,6 @@
             xmlns:bpm="urn:switchyard-component-bpm:config:1.0"
             xmlns:soap="urn:switchyard-component-soap:config:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstart-demo:helpdesk:0.1.0-SNAPSHOT"
             name="helpdesk">
     <sca:composite name="helpdesk">
         <sca:service name="HelpDeskService" promote="HelpDeskService">

--- a/demos/orders/src/main/resources/META-INF/switchyard.xml
+++ b/demos/orders/src/main/resources/META-INF/switchyard.xml
@@ -5,7 +5,6 @@
             xmlns:bean="urn:switchyard-component-bean:config:1.0"
             xmlns:soap="urn:switchyard-component-soap:config:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstart-demo:orders:0.1.0-SNAPSHOT"
             name="orders">
     <sca:composite name="orders">
         <sca:service name="OrderService" promote="OrderService">

--- a/rules-interview/src/main/resources/META-INF/switchyard.xml
+++ b/rules-interview/src/main/resources/META-INF/switchyard.xml
@@ -3,8 +3,7 @@
             xmlns:swyd="urn:switchyard-config:switchyard:1.0"
             xmlns:rules="urn:switchyard-component-rules:config:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstart:rules-interview:0.2.0-SNAPSHOT"
-            name="Interview">
+            name="rules-interview">
     <sca:composite name="Interview">
         <sca:service name="Interview">
             <interface.java interface="org.switchyard.quickstarts.rules.interview.Interview" promote="Interview"/>

--- a/transform-json/src/main/resources/META-INF/switchyard.xml
+++ b/transform-json/src/main/resources/META-INF/switchyard.xml
@@ -2,8 +2,7 @@
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
             xmlns:trfm="urn:switchyard-config:transform:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstart:transform-json:1.0-SNAPSHOT"
-            name="transform-smooks">
+            name="transform-json">
             
     <transforms>
         <trfm:transform.json 

--- a/transform-smooks/src/main/resources/META-INF/switchyard.xml
+++ b/transform-smooks/src/main/resources/META-INF/switchyard.xml
@@ -3,7 +3,6 @@
             xmlns:trfm="urn:switchyard-config:transform:1.0"
             xmlns:soap="urn:switchyard-component-soap:config:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstart:transform-smooks:1.0-SNAPSHOT"
             name="transform-smooks">
             
     <transforms>


### PR DESCRIPTION
SWITCHYARD-365: targetNamespace is being ignored by NamedModel.getQName()
https://issues.jboss.org/browse/SWITCHYARD-365
