### PR TITLE
SWITCHYARD-365: targetNamespace is being ignored by NamedModel.getQName()

### DIFF
--- a/camel-binding/src/main/resources/META-INF/switchyard.xml
+++ b/camel-binding/src/main/resources/META-INF/switchyard.xml
@@ -1,6 +1,6 @@
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
             xmlns:camel="urn:switchyard-component-camel:config:1.0">
-    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="camel-binding">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="camel-binding" targetNamespace="urn:switchyard-quickstart:camel-binding:0.1.0">
     
         <service name="GreetingService" promote="GreetingService">
             <camel:binding.camel configURI="file://target/input?fileName=test.txt&amp;initialDelay=50&amp;delete=true"/>

--- a/camel-jms-binding/src/main/resources/META-INF/switchyard.xml
+++ b/camel-jms-binding/src/main/resources/META-INF/switchyard.xml
@@ -1,6 +1,6 @@
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
             xmlns:camel="urn:switchyard-component-camel:config:1.0">
-    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="camel-binding">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="camel-jms-binding" targetNamespace="urn:switchyard-quickstart:camel-jms-binding:0.1.0">
     
         <service name="GreetingService" promote="GreetingService">
             <!--camel:binding.camel configURI="jms://GreetingServiceQueue?connectionFactory=#RemoteConnectionFactory"/-->

--- a/camel-service/src/main/resources/META-INF/switchyard.xml
+++ b/camel-service/src/main/resources/META-INF/switchyard.xml
@@ -1,16 +1,16 @@
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0">
-    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="camel-service">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="camel-service" targetNamespace="urn:switchyard-quickstart:camel-service:0.1.0">
+        <service name="JavaDSL" promote="JavaDSLBuilder/JavaDSL"/>
         <component name="XMLComponent">
-            <service name="XMLService">
-                <interface.java interface="org.switchyard.quickstarts.camel.service.JavaDSL"/>
-            </service>
             <implementation.camel xmlns="urn:switchyard-component-camel:config:1.0">
                 <route xmlns="http://camel.apache.org/schema/spring">
                     <log message="Inside XML Camel Route"/>
                     <log message="[message] '${body}'"/>
                 </route>
             </implementation.camel>
+            <service name="XMLService">
+                <interface.java interface="org.switchyard.quickstarts.camel.service.JavaDSL"/>
+            </service>
         </component>
-        <service name="JavaDSL" promote="JavaDSLBuilder/JavaDSL"/>
     </composite>
 </switchyard>

--- a/demos/helpdesk/src/main/resources/META-INF/HelpDeskService.bpmn
+++ b/demos/helpdesk/src/main/resources/META-INF/HelpDeskService.bpmn
@@ -34,7 +34,7 @@
       <dataInputAssociation>
         <targetRef>_4_ServiceNameInput</targetRef>
         <assignment>
-          <from xsi:type="tFormalExpression">TicketManagementService</from>
+          <from xsi:type="tFormalExpression">{urn:switchyard-quickstart-demo:helpdesk:0.1.0}TicketManagementService</from>
           <to xsi:type="tFormalExpression">_4_ServiceNameInput</to>
         </assignment>
       </dataInputAssociation>
@@ -60,7 +60,7 @@
       <dataInputAssociation>
         <targetRef>_5_ServiceNameInput</targetRef>
         <assignment>
-          <from xsi:type="tFormalExpression">TicketManagementService</from>
+          <from xsi:type="tFormalExpression">{urn:switchyard-quickstart-demo:helpdesk:0.1.0}TicketManagementService</from>
           <to xsi:type="tFormalExpression">_5_ServiceNameInput</to>
         </assignment>
       </dataInputAssociation>
@@ -172,7 +172,7 @@ kcontext.setVariable("ticket", ticket);</script>
       <dataInputAssociation>
         <targetRef>_12_ServiceNameInput</targetRef>
         <assignment>
-          <from xsi:type="tFormalExpression">TicketManagementService</from>
+          <from xsi:type="tFormalExpression">{urn:switchyard-quickstart-demo:helpdesk:0.1.0}TicketManagementService</from>
           <to xsi:type="tFormalExpression">_12_ServiceNameInput</to>
         </assignment>
       </dataInputAssociation>
@@ -229,7 +229,7 @@ kcontext.setVariable("ticket", ticket);</script>
       <dataInputAssociation>
         <targetRef>_14_ServiceNameInput</targetRef>
         <assignment>
-          <from xsi:type="tFormalExpression">TicketManagementService</from>
+          <from xsi:type="tFormalExpression">{urn:switchyard-quickstart-demo:helpdesk:0.1.0}TicketManagementService</from>
           <to xsi:type="tFormalExpression">_14_ServiceNameInput</to>
         </assignment>
       </dataInputAssociation>
@@ -258,7 +258,7 @@ kcontext.setVariable("ticket", ticket);</script>
       <dataInputAssociation>
         <targetRef>_16_ServiceNameInput</targetRef>
         <assignment>
-          <from xsi:type="tFormalExpression">TicketManagementService</from>
+          <from xsi:type="tFormalExpression">{urn:switchyard-quickstart-demo:helpdesk:0.1.0}TicketManagementService</from>
           <to xsi:type="tFormalExpression">_16_ServiceNameInput</to>
         </assignment>
       </dataInputAssociation>

--- a/demos/helpdesk/src/main/resources/META-INF/switchyard.xml
+++ b/demos/helpdesk/src/main/resources/META-INF/switchyard.xml
@@ -1,25 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<switchyard xmlns="urn:switchyard-config:switchyard:1.0"
-            xmlns:swyd="urn:switchyard-config:switchyard:1.0"
-            xmlns:trfm="urn:switchyard-config:transform:1.0"
-            xmlns:bean="urn:switchyard-component-bean:config:1.0"
-            xmlns:bpm="urn:switchyard-component-bpm:config:1.0"
-            xmlns:soap="urn:switchyard-component-soap:config:1.0"
-            xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstart-demo:helpdesk:0.1.0-SNAPSHOT"
-            name="helpdesk">
-    <sca:composite name="helpdesk">
-        <sca:service name="HelpDeskService" promote="HelpDeskService">
-            <soap:binding.soap>
-                <soap:serverPort>18001</soap:serverPort>
-                <soap:wsdl>META-INF/HelpDeskService.wsdl</soap:wsdl>
-                <soap:composer
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0" name="helpdesk">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="helpdesk" targetNamespace="urn:switchyard-quickstart-demo:helpdesk:0.1.0">
+        <service name="HelpDeskService" promote="HelpDeskService">
+            <binding.soap xmlns="urn:switchyard-component-soap:config:1.0">
+                <wsdl>META-INF/HelpDeskService.wsdl</wsdl>
+                <serverPort>18001</serverPort>
+                <composer
                     mappedVariableNamespace="urn:switchyard-component-bpm:process:1.0"
                     mappedVariableNames="processActionType,processInstanceId"/>
-                <soap:decomposer
+                <decomposer
                     mappedVariableNamespace="urn:switchyard-component-bpm:process:1.0"
                     mappedVariableNames="processInstanceId"/>
-            </soap:binding.soap>
-        </sca:service>
-    </sca:composite>
+            </binding.soap>
+        </service>
+    </composite>
 </switchyard>

--- a/demos/orders/src/main/resources/META-INF/switchyard.xml
+++ b/demos/orders/src/main/resources/META-INF/switchyard.xml
@@ -1,18 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<switchyard xmlns="urn:switchyard-config:switchyard:1.0"
-            xmlns:swyd="urn:switchyard-config:switchyard:1.0"
-            xmlns:trfm="urn:switchyard-config:transform:1.0"
-            xmlns:bean="urn:switchyard-component-bean:config:1.0"
-            xmlns:soap="urn:switchyard-component-soap:config:1.0"
-            xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstart-demo:orders:0.1.0-SNAPSHOT"
-            name="orders">
-    <sca:composite name="orders">
-        <sca:service name="OrderService" promote="OrderService">
-            <soap:binding.soap>
-                <soap:serverPort>18001</soap:serverPort>
-                <soap:wsdl>wsdl/OrderService.wsdl</soap:wsdl>
-            </soap:binding.soap>
-        </sca:service>
-    </sca:composite>
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0" name="orders">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="orders" targetNamespace="urn:switchyard-quickstart-demo:orders:0.1.0">
+        <service name="OrderService" promote="OrderService">
+            <binding.soap xmlns="urn:switchyard-component-soap:config:1.0">
+                <wsdl>wsdl/OrderService.wsdl</wsdl>
+                <serverPort>18001</serverPort>
+            </binding.soap>
+        </service>
+    </composite>
 </switchyard>

--- a/demos/webapp-deploy/src/main/resources/META-INF/switchyard.xml
+++ b/demos/webapp-deploy/src/main/resources/META-INF/switchyard.xml
@@ -5,9 +5,8 @@
             xmlns:bean="urn:switchyard-component-bean:config:1.0"
             xmlns:soap="urn:switchyard-component-soap:config:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstart-demo:orders:0.1.0-SNAPSHOT"
             name="orders">
-    <sca:composite name="orders">
+    <sca:composite name="orders" targetNamespace="urn:switchyard-quickstart-demo:webapp-deploy:0.1.0">
         <sca:service name="OrderService" promote="OrderService">
             <soap:binding.soap>
                 <soap:serverPort>18001</soap:serverPort>

--- a/hornetq-binding/src/main/resources/META-INF/switchyard.xml
+++ b/hornetq-binding/src/main/resources/META-INF/switchyard.xml
@@ -3,7 +3,7 @@
 		    xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
 		    xmlns:bean="urn:switchyard-component-bean:config:1.0">
             
-    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="hornetq-service-binding">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="hornetq-binding" targetNamespace="urn:switchyard-quickstart:hornetq-binding:0.1.0">
     
         <service name="GreetingService" promote="GreetingService">
             <hornetq:binding.hornetq>

--- a/rules-interview/src/main/resources/META-INF/switchyard.xml
+++ b/rules-interview/src/main/resources/META-INF/switchyard.xml
@@ -3,11 +3,10 @@
             xmlns:swyd="urn:switchyard-config:switchyard:1.0"
             xmlns:rules="urn:switchyard-component-rules:config:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstart:rules-interview:0.2.0-SNAPSHOT"
-            name="Interview">
-    <sca:composite name="Interview">
-        <sca:service name="Interview">
-            <interface.java interface="org.switchyard.quickstarts.rules.interview.Interview" promote="Interview"/>
+            name="rules-interview">
+    <sca:composite name="Interview" targetNamespace="urn:switchyard-quickstart:rules-interview:0.1.0">
+        <sca:service name="Interview" promote="Interview">
+            <sca:interface.java interface="org.switchyard.quickstarts.rules.interview.Interview"/>
         </sca:service>
     </sca:composite>
 </switchyard>

--- a/transform-jaxb/src/main/resources/META-INF/switchyard.xml
+++ b/transform-jaxb/src/main/resources/META-INF/switchyard.xml
@@ -1,10 +1,10 @@
-<switchyard xmlns="urn:switchyard-config:switchyard:1.0" xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" xmlns:soap="urn:switchyard-component-soap:config:1.0">
-    <sca:composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="switchyard-quickstart-transform-jaxb">
-        <sca:service name="OrderService" promote="OrderService">
-            <soap:binding.soap>
-                <soap:serverPort>18001</soap:serverPort>
-                <soap:wsdl>wsdl/OrderService.wsdl</soap:wsdl>
-            </soap:binding.soap>
-        </sca:service>
-	</sca:composite>
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="transform-jaxb" targetNamespace="urn:switchyard-quickstart:transform-jaxb:0.1.0">
+        <service name="OrderService" promote="OrderService">
+            <binding.soap xmlns="urn:switchyard-component-soap:config:1.0">
+                <wsdl>wsdl/OrderService.wsdl</wsdl>
+                <serverPort>18001</serverPort>
+            </binding.soap>
+        </service>
+	</composite>
 </switchyard>

--- a/transform-json/src/main/resources/META-INF/switchyard.xml
+++ b/transform-json/src/main/resources/META-INF/switchyard.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
             xmlns:trfm="urn:switchyard-config:transform:1.0"
+            xmlns:soap="urn:switchyard-component-soap:config:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstart:transform-json:1.0-SNAPSHOT"
-            name="transform-smooks">
-            
+            name="transform-json">
+
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="transform-json" targetNamespace="urn:switchyard-quickstart:transform-json:0.1.0"/>
+
     <transforms>
         <trfm:transform.json 
             from="java:org.switchyard.quickstarts.transform.json.OrderAck" 
             to="{urn:switchyard-quickstart:transform-json:1.0}orderResponse"/>
-            
         <trfm:transform.json 
             from="{urn:switchyard-quickstart:transform-json:1.0}order" 
             to="java:org.switchyard.quickstarts.transform.json.Order"/>

--- a/transform-smooks/src/main/resources/META-INF/switchyard.xml
+++ b/transform-smooks/src/main/resources/META-INF/switchyard.xml
@@ -3,15 +3,15 @@
             xmlns:trfm="urn:switchyard-config:transform:1.0"
             xmlns:soap="urn:switchyard-component-soap:config:1.0"
             xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912"
-            targetNamespace="urn:switchyard-quickstart:transform-smooks:1.0-SNAPSHOT"
             name="transform-smooks">
-            
+
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="transform-smooks" targetNamespace="urn:switchyard-quickstart:transform-smooks:0.1.0"/>
+
     <transforms>
         <trfm:transform.smooks type="JAVA2XML" 
             from="java:org.switchyard.quickstarts.transform.smooks.OrderAck" 
             to="{urn:switchyard-quickstart:transform-smooks:1.0}submitOrderResponse" 
             config="/smooks/OrderAck_XML.xml" />
-    
         <trfm:transform.smooks type="XML2JAVA" 
             from="{urn:switchyard-quickstart:transform-smooks:1.0}submitOrder" 
             to="java:org.switchyard.quickstarts.transform.smooks.Order" 


### PR DESCRIPTION
SWITCHYARD-365: targetNamespace is being ignored by NamedModel.getQName()
https://issues.jboss.org/browse/SWITCHYARD-365
