### PR TITLE
SWITCHYARD-423: merged config is not schema valid

### DIFF
--- a/demos/webapp-deploy/src/main/resources/META-INF/switchyard.xml
+++ b/demos/webapp-deploy/src/main/resources/META-INF/switchyard.xml
@@ -9,8 +9,8 @@
     <sca:composite name="orders" targetNamespace="urn:switchyard-quickstart-demo:webapp-deploy:0.1.0">
         <sca:service name="OrderService" promote="OrderService">
             <soap:binding.soap>
-                <soap:serverPort>18001</soap:serverPort>
                 <soap:wsdl>wsdl/OrderService.wsdl</soap:wsdl>
+                <soap:serverPort>18001</soap:serverPort>
             </soap:binding.soap>
         </sca:service>
     </sca:composite>


### PR DESCRIPTION
SWITCHYARD-423: merged config is not schema valid
https://issues.jboss.org/browse/SWITCHYARD-423
This bubbled out as it exposed places in our models where we don't set the proper order according to the schemas, once validation was also enforced at the post-merge phase of the switchyard configure plugin.
