### PR TITLE
SWITCHYARD-434: Update BPMMixIn to use the TestMixIn lifecycle methods

### DIFF
--- a/demos/helpdesk/src/test/java/org/switchyard/quickstarts/demos/helpdesk/HelpDeskTests.java
+++ b/demos/helpdesk/src/test/java/org/switchyard/quickstarts/demos/helpdesk/HelpDeskTests.java
@@ -40,22 +40,11 @@ import org.switchyard.transform.config.model.TransformSwitchYardScanner;
 )
 public class HelpDeskTests {
 
-    private BPMMixIn bpm;
     private HTTPMixIn http;
 
     @Test
     public void testHelpDesk() throws Exception {
-        if (bpm.startTaskServer("Developer", "User")) {
-            try {
-                http.postResourceAndTestXML("http://localhost:18001/HelpDeskService", "/xml/soap-request.xml", "/xml/soap-response.xml");
-                boolean keepWorking = true;
-                while (keepWorking) {
-                    keepWorking = bpm.completeTasksForUsers("Developer", "User");
-                }
-            } finally {
-                bpm.stopTaskServer();
-            }
-        }
+        http.postResourceAndTestXML("http://localhost:18001/HelpDeskService", "/xml/soap-request.xml", "/xml/soap-response.xml");
     }
 
 }


### PR DESCRIPTION
Update BPMMixIn to use the TestMixIn lifecycle methods (initialize() and uninitialize()) to start and stop the bpm task server

https://issues.jboss.org/browse/SWITCHYARD-434
