### PR TITLE
SWITCHYARD-529 ensure all quickstarts use unique names in their config

### DIFF
--- a/bean-service/src/main/resources/META-INF/switchyard.xml
+++ b/bean-service/src/main/resources/META-INF/switchyard.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<switchyard xmlns="urn:switchyard-config:switchyard:1.0" name="orders">
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0" name="orders" targetNamespace="urn:switchyard-quickstart:bean-service:0.1.0">
     <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="orders" targetNamespace="urn:switchyard-quickstart:bean-service:0.1.0">
         <service name="OrderService" promote="OrderService">
             <binding.soap xmlns="urn:switchyard-component-soap:config:1.0">
                 <wsdl>wsdl/OrderService.wsdl</wsdl>
                 <socketAddr>:18001</socketAddr>
+                <contextPath>quickstart-bean</contextPath>
             </binding.soap>
         </service>
     </composite>

--- a/bean-service/src/test/java/org/switchyard/quickstarts/bean/service/WebServiceTest.java
+++ b/bean-service/src/test/java/org/switchyard/quickstarts/bean/service/WebServiceTest.java
@@ -41,7 +41,7 @@ public class WebServiceTest {
     public void invokeOrderWebService() throws Exception {
         // Use the HttpMixIn to invoke the SOAP binding endpoint with a SOAP input (from the test classpath)
         // and compare the SOAP response to a SOAP response resource (from the test classpath)...
-        httpMixIn.postResourceAndTestXML("http://localhost:18001/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
+        httpMixIn.postResourceAndTestXML("http://localhost:18001/quickstart-bean/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
     }
 }
 

--- a/demos/orders/src/main/webResources/META-INF/switchyard.xml
+++ b/demos/orders/src/main/webResources/META-INF/switchyard.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<switchyard xmlns="urn:switchyard-config:switchyard:1.0" name="orders">
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0" name="orders" targetNamespace="urn:switchyard-quickstart-demo:orders:0.1.0">
     <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="orders" targetNamespace="urn:switchyard-quickstart-demo:orders:0.1.0">
         <service name="OrderService" promote="OrderService">
             <binding.soap xmlns="urn:switchyard-component-soap:config:1.0">
                 <wsdl>wsdl/OrderService.wsdl</wsdl>
                 <socketAddr>:18001</socketAddr>
+                <contextPath>demo-orders</contextPath>
             </binding.soap>
         </service>
     </composite>

--- a/demos/orders/src/test/java/org/switchyard/quickstarts/demos/orders/WebServiceTest.java
+++ b/demos/orders/src/test/java/org/switchyard/quickstarts/demos/orders/WebServiceTest.java
@@ -41,7 +41,7 @@ public class WebServiceTest {
     public void invokeOrderWebService() throws Exception {
         // Use the HttpMixIn to invoke the SOAP binding endpoint with a SOAP input (from the test classpath)
         // and compare the SOAP response to a SOAP response resource (from the test classpath)...
-        httpMixIn.postResourceAndTestXML("http://localhost:18001/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
+        httpMixIn.postResourceAndTestXML("http://localhost:18001/demo-orders/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
     }
 }
 

--- a/transform-jaxb/src/main/resources/META-INF/switchyard.xml
+++ b/transform-jaxb/src/main/resources/META-INF/switchyard.xml
@@ -1,9 +1,10 @@
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0">
-    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="transform-jaxb" targetNamespace="urn:switchyard-quickstart:transform-jaxb:0.1.0">
+    <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="transform-jaxb" targetNamespace="urn:switchyard-quickstart:transform-jaxb:1.0">
         <service name="OrderService" promote="OrderService">
             <binding.soap xmlns="urn:switchyard-component-soap:config:1.0">
                 <wsdl>wsdl/OrderService.wsdl</wsdl>
                 <socketAddr>:18001</socketAddr>
+                <contextPath>quickstart-transform-jaxb</contextPath>
             </binding.soap>
         </service>
 	</composite>

--- a/transform-jaxb/src/test/java/org/switchyard/quickstarts/transform/jaxb/WebServiceTest.java
+++ b/transform-jaxb/src/test/java/org/switchyard/quickstarts/transform/jaxb/WebServiceTest.java
@@ -42,6 +42,6 @@ public class WebServiceTest {
         // Use the HttpMixIn to invoke the SOAP binding endpoint with a SOAP input (from the test classpath)
         // and compare the SOAP response to a SOAP response resource (from the test classpath)...
         httpMixIn.
-            postResourceAndTestXML("http://localhost:18001/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
+            postResourceAndTestXML("http://localhost:18001/quickstart-transform-jaxb/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
     }
 }

--- a/transform-xslt/src/main/resources/META-INF/switchyard.xml
+++ b/transform-xslt/src/main/resources/META-INF/switchyard.xml
@@ -4,6 +4,7 @@
             <binding.soap xmlns="urn:switchyard-component-soap:config:1.0">
                 <wsdl>wsdl/OrderService.wsdl</wsdl>
                 <socketAddr>:18001</socketAddr>
+                <contextPath>quickstart-transform-xslt</contextPath>
             </binding.soap>
          </service>
     </composite>

--- a/transform-xslt/src/test/java/org/switchyard/quickstarts/transform/xslt/WebServiceTest.java
+++ b/transform-xslt/src/test/java/org/switchyard/quickstarts/transform/xslt/WebServiceTest.java
@@ -42,6 +42,6 @@ public class WebServiceTest {
         // Use the HttpMixIn to invoke the SOAP binding endpoint with a SOAP input (from the test classpath)
         // and compare the SOAP response to a SOAP response resource (from the test classpath)...
         httpMixIn.
-            postResourceAndTestXML("http://localhost:18001/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
+            postResourceAndTestXML("http://localhost:18001/quickstart-transform-xslt/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
     }
 }


### PR DESCRIPTION
there is a corresponding pull on release
