### PR TITLE
SWITCHYARD-636, added library needed for JNDI registration in BPEL component

### DIFF
--- a/bpel-service/pom.xml
+++ b/bpel-service/pom.xml
@@ -79,6 +79,16 @@
       <artifactId>persistence-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.as</groupId>
+      <artifactId>jboss-as-naming</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.as</groupId>
+      <artifactId>jboss-as-server</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
This is the last part of the SWITHYARD-636 task.
