### PR TITLE
SWITCHYARD-717: Objects need to be re-set into TaskContent for serialization

### DIFF
--- a/demos/helpdesk-webapp/src/main/java/org/switchyard/quickstarts/demos/helpdesk/HelpDesk.java
+++ b/demos/helpdesk-webapp/src/main/java/org/switchyard/quickstarts/demos/helpdesk/HelpDesk.java
@@ -133,7 +133,6 @@ public class HelpDesk {
                         Map<String, Object> results = taskContent.getMap();
                         Ticket ticket = _userTickets.get(task.getProcessInstanceId());
                         results.put(TICKET, ticket);
-                        taskContent.setMap(results);
                         _taskClient.complete(task.getId(), _userId, taskContent);
                     }
                 }


### PR DESCRIPTION
SWITCHYARD-717: Objects need to be re-set into TaskContent for serialization
https://issues.jboss.org/browse/SWITCHYARD-717
