### PR TITLE
SWITCHYARD-710: Allow direct storage of XML Nodes as Context properties from ContextMappers

### DIFF
--- a/camel-soap-proxy/src/main/resources/META-INF/switchyard.xml
+++ b/camel-soap-proxy/src/main/resources/META-INF/switchyard.xml
@@ -8,14 +8,14 @@
     <sca:composite name="camel-soap-proxy" targetNamespace="urn:switchyard-quickstart:camel-soap-proxy:1.0">
         <sca:service name="ProxyService" promote="ProxyService">
             <soap:binding.soap>
-                <swyd:contextMapper/>
+                <soap:contextMapper/>
                 <soap:wsdl>META-INF/ReverseService.wsdl</soap:wsdl>
                 <soap:socketAddr>:18002</soap:socketAddr>
             </soap:binding.soap>
         </sca:service>
         <sca:reference name="ReverseService" promote="ProxyService/ReverseService" multiplicity="0..1">
             <soap:binding.soap>
-                <swyd:contextMapper/>
+                <soap:contextMapper/>
                 <soap:wsdl>META-INF/ReverseService.wsdl</soap:wsdl>
             </soap:binding.soap>
         </sca:reference>

--- a/demos/helpdesk-webapp/src/main/resources/META-INF/switchyard.xml
+++ b/demos/helpdesk-webapp/src/main/resources/META-INF/switchyard.xml
@@ -4,7 +4,7 @@
         <service name="HelpDeskService" promote="HelpDeskService">
             <interface.wsdl interface="META-INF/HelpDeskService.wsdl#wsdl.porttype(HelpDeskService)"/>
             <binding.soap xmlns="urn:switchyard-component-soap:config:1.0">
-                <contextMapper includeNamespaces="urn:switchyard-component-bpm:process:1.0" xmlns="urn:switchyard-config:switchyard:1.0"/>
+                <contextMapper includeNamespaces="urn:switchyard-component-bpm:process:1.0"/>
                 <wsdl>META-INF/HelpDeskService.wsdl</wsdl>
                 <socketAddr>:18001</socketAddr>
             </binding.soap>

--- a/demos/helpdesk/src/main/resources/META-INF/switchyard.xml
+++ b/demos/helpdesk/src/main/resources/META-INF/switchyard.xml
@@ -4,7 +4,7 @@
         <service name="HelpDeskService" promote="HelpDeskService">
             <interface.wsdl interface="META-INF/HelpDeskService.wsdl#wsdl.porttype(HelpDeskService)"/>
             <binding.soap xmlns="urn:switchyard-component-soap:config:1.0">
-                <contextMapper includeNamespaces="urn:switchyard-component-bpm:process:1.0" xmlns="urn:switchyard-config:switchyard:1.0"/>
+                <contextMapper includeNamespaces="urn:switchyard-component-bpm:process:1.0"/>
                 <wsdl>META-INF/HelpDeskService.wsdl</wsdl>
                 <socketAddr>:18001</socketAddr>
             </binding.soap>


### PR DESCRIPTION
SWITCHYARD-710: Allow direct storage of XML Nodes as Context properties from ContextMappers
https://issues.jboss.org/browse/SWITCHYARD-710
