### PR TITLE
SWITCHYARD-768 Add configuration support for Camel JMS component

### DIFF
--- a/camel-jms-binding/src/main/resources/META-INF/switchyard.xml
+++ b/camel-jms-binding/src/main/resources/META-INF/switchyard.xml
@@ -3,8 +3,11 @@
     <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="camel-jms-binding" targetNamespace="urn:switchyard-quickstart:camel-jms-binding:0.1.0">
     
         <service name="GreetingService" promote="GreetingService">
-            <camel:binding.camel configURI="jms://GreetingServiceQueue?connectionFactory=#ConnectionFactory"/>
+            <camel:binding.jms>
+                <camel:queue>GreetingServiceQueue</camel:queue>
+                <camel:connectionFactory>#ConnectionFactory</camel:connectionFactory>
+            </camel:binding.jms>
         </service>
-        
+
     </composite>
 </switchyard>


### PR DESCRIPTION
Port camel-jms-binding to use binding.jms instead of generic configURI.
