### PR TITLE
SWITCHYARD-1001: HttpContextMapper and RESTEasyContextMapper should support regex

### DIFF
--- a/http-binding/src/main/resources/META-INF/switchyard.xml
+++ b/http-binding/src/main/resources/META-INF/switchyard.xml
@@ -29,6 +29,7 @@
 
         <sca:service name="SymbolService" promote="SymbolService/SymbolService">
             <http:binding.http>
+                <http:contextMapper includes="[cC]ontent-type"/>
                 <http:contextPath>http-binding/symbol</http:contextPath>
                 <http:operationSelector>getSymbol</http:operationSelector>
             </http:binding.http>


### PR DESCRIPTION
SWITCHYARD-1001: HttpContextMapper and RESTEasyContextMapper should support regex
https://issues.jboss.org/browse/SWITCHYARD-1001
