### PR TITLE
SWITCHYARD-968 Add an one-stop deployment method for quickstarts

### DIFF
--- a/bean-service/Readme.md
+++ b/bean-service/Readme.md
@@ -20,7 +20,7 @@ JBoss AS 7
 2. Start JBoss AS 7 in standalone mode:
     ${AS}/bin/standalone.sh
 3. Deploy the Quickstart : 
-    cp target/switchyard-quickstart-bean-service.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 4. Submit a webservice request to invoke the SOAP gateway.  There are a number of ways to do this :
       - Submit a request with your preferred SOAP client - src/test/resources/xml contains sample 
         requests and the responses that you should see

--- a/bpel-service/Readme.md
+++ b/bpel-service/Readme.md
@@ -29,7 +29,7 @@ JBoss AS 7, say_hello
 2. Start JBoss AS 7 in standalone mode:
     ${AS}/bin/standalone.sh
 3. Deploy the Quickstart : 
-    cp target/switchyard-quickstart-bpel-service-say-hello.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 4. Submit a webservice request to invoke the SOAP gateway.  There are a number of ways to do this :
       - Submit a request with your preferred SOAP client - src/test/resources/xml contains sample 
         requests and the responses that you should see
@@ -59,7 +59,7 @@ JBoss AS 7, loan_service
 2. Start JBoss AS 7 in standalone mode:
     ${AS}/bin/standalone.sh
 3. Deploy the Quickstart :
-    cp target/switchyard-quickstart-bpel-service-loan-approval.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 4. Submit a webservice request to invoke the SOAP gateway.  There are a
    number of ways to do this :
       - Submit a request with your preferred SOAP client - src/test/resources/xml contains sample requests 

--- a/bpel-service/jms_binding/Readme.md
+++ b/bpel-service/jms_binding/Readme.md
@@ -24,7 +24,7 @@ JBoss AS 7
 5. Deploy JMS Queue
     cp src/test/resources/switchyard-quickstart-bpel-jms-hornetq-jms.xml ${AS7}/standalone/deployments
 6. Deploy the quickstart
-    cp target/switchyard-quickstart-bpel-service-jms-binding.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 7. Execute HornetQClient
     mvn exec:java
 8. Watch the command output for the reply message.

--- a/bpel-service/simple_correlation/README.md
+++ b/bpel-service/simple_correlation/README.md
@@ -21,7 +21,7 @@ JBoss AS 7, simple_correlation
 2. Start JBoss AS 7 in standalone mode:
     ${AS}/bin/standalone.sh
 3. Deploy the Quickstart :
-    cp target/switchyard-quickstart-bpel-service-simple-correlation.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 4. Submit a webservice request to invoke the SOAP gateway.  There are a number of ways to do this :
       - Submit a request with your preferred SOAP client - src/test/resources/xml contains sample
         requests and the responses that you should see

--- a/bpel-service/xts_subordinate_wsba/Readme.md
+++ b/bpel-service/xts_subordinate_wsba/Readme.md
@@ -20,8 +20,7 @@ JBoss AS 7
 2. Start JBoss AS 7 in standalone-xts mode:
     ${AS}/bin/standalone.sh --server-config=standalone-xts.xml
 3. Deploy the BPEL process and the Web service :
-    cp bpel/target/switchyard-quickstart-bpel-service-xts-subordinate-wsba-bpel.jar ${AS7}/standalone/deployments
-    cp ws/target/switchyard-quickstart-bpel-service-xts-subordinate-wsba-ws.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 4. Submit a webservice requests to invoke the SOAP gateway.  There are a number of ways to do this :
       - Submit a request with your preferred SOAP client - bpel/src/test/resources/xml contains sample
         requests and the responses that you should see

--- a/bpel-service/xts_subordinate_wsba/ws/pom.xml
+++ b/bpel-service/xts_subordinate_wsba/ws/pom.xml
@@ -46,6 +46,13 @@
 				</archive>
 			</configuration>
 		</plugin>
+		<plugin>
+			<groupId>org.jboss.as.plugins</groupId>
+			<artifactId>jboss-as-maven-plugin</artifactId>
+			<configuration>
+				<filename>${project.build.finalName}.jar</filename>
+			</configuration>
+		</plugin>
 		</plugins>
 	</build>
 

--- a/bpel-service/xts_wsat/Readme.md
+++ b/bpel-service/xts_wsat/Readme.md
@@ -21,8 +21,7 @@ JBoss AS 7
 2. Start JBoss AS 7 in standalone-xts mode:
     ${AS}/bin/standalone.sh --server-config=standalone-xts.xml
 3. Deploy the BPEL process and the Web service :
-    cp bpel/target/switchyard-quickstart-bpel-service-xts-wsat-bpel.jar ${AS7}/standalone/deployments
-    cp ws/target/switchyard-quickstart-bpel-service-xts-wsat-ws.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 4. Submit a webservice requests to invoke the SOAP gateway.  There are a number of ways to do this :
       - Submit a request with your preferred SOAP client - bpel/src/test/resources/xml contains sample
         requests and the responses that you should see

--- a/bpel-service/xts_wsat/ws/pom.xml
+++ b/bpel-service/xts_wsat/ws/pom.xml
@@ -46,6 +46,13 @@
 				</archive>
 			</configuration>
 		</plugin>
+		<plugin>
+			<groupId>org.jboss.as.plugins</groupId>
+			<artifactId>jboss-as-maven-plugin</artifactId>
+			<configuration>
+				<filename>${project.build.finalName}.jar</filename>
+			</configuration>
+		</plugin>
 		</plugins>
 	</build>
 

--- a/bpm-service/Readme.md
+++ b/bpm-service/Readme.md
@@ -27,7 +27,7 @@ JBoss AS 7
 2. Start JBoss AS 7 in standalone mode:
     ${AS}/bin/standalone.sh
 3. Deploy the Quickstart : 
-    cp target/switchyard-quickstart-bpm-service.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 4. Submit a webservice request to invoke the SOAP gateway.  There are a number of ways to do this :
       - Submit a request with your preferred SOAP client - src/test/resources/xml contains sample 
         requests and the responses that you should see

--- a/camel-ftp-binding/Readme.md
+++ b/camel-ftp-binding/Readme.md
@@ -15,7 +15,7 @@ JBoss AS 7
 3. Start JBoss AS 7 in standalone-full mode:
     ${AS}/bin/standalone.sh --server-config=standalone-full.xml
 4. Deploy the quickstart
-    cp target/switchyard-quickstarts-camel-ftp-binding.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 5. Create file on ftp server using standalone client
 6. Check the server console for output from the service.
 

--- a/camel-jms-binding/Readme.md
+++ b/camel-jms-binding/Readme.md
@@ -22,7 +22,7 @@ JBoss AS 7
 5. Deploy JMS Queue
     cp src/test/resources/switchyard-quickstart-camel-jms-binding-hornetq-jms.xml ${AS7}/standalone/deployments
 6. Deploy the quickstart
-    cp target/switchyard-quickstarts-camel-jms-binding.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 7. Execute HornetQClient
     mvn exec:java
 8. Check the server console for output from the service.

--- a/camel-netty-binding/Readme.md
+++ b/camel-netty-binding/Readme.md
@@ -13,7 +13,7 @@ JBoss AS 7
 2. Start JBoss AS 7 in standalone-full mode:
     ${AS}/bin/standalone.sh --server-config=standalone-full.xml
 3. Deploy the quickstart
-    cp target/switchyard-quickstarts-camel-netty-binding.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 4. Execute client and send text message:
     a) for tcp test use: mvn exec:java
     b) for udp test use: mvn exec:java -Pudp

--- a/camel-quartz-binding/Readme.md
+++ b/camel-quartz-binding/Readme.md
@@ -13,7 +13,7 @@ JBoss AS 7
 2. Start JBoss AS 7 in standalone-full mode:
     ${AS}/bin/standalone.sh --server-config=standalone-full.xml
 3. Deploy the quickstart
-    cp target/switchyard-quickstarts-camel-quartz-binding.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 4. Check the server console for output from the service. By default after every second
    message should be printed
 

--- a/camel-rest-binding/Readme.md
+++ b/camel-rest-binding/Readme.md
@@ -31,7 +31,7 @@ JBoss AS 7
 </pre>
 3. Deploy the quickstart
 <pre>
-    cp target/switchyard-quickstarts-camel-rest-binding.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 </pre>
 4. Open a console windows and type  
 <pre>

--- a/camel-soap-proxy/Readme.md
+++ b/camel-soap-proxy/Readme.md
@@ -23,7 +23,7 @@ JBoss AS 7
 3. Deploy the Web Service :
     cp target/ReverseService.war ${AS7}/standalone/deployments
 4. Deploy the Quickstart :
-    cp target/switchyard-quickstarts-camel-soap-proxy.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 5. Using http://localhost:8080/proxy/ReverseService as the endpoint url, submit a request
    with your preferred SOAP client - src/test/resources/xml contains sample requests and
    the responses that you should see

--- a/demos/helpdesk-webapp/Readme.md
+++ b/demos/helpdesk-webapp/Readme.md
@@ -28,7 +28,7 @@ JBoss AS 7
 2. Start the application server:
     cd switchyard-as7-0.5/bin ; ./standalone.sh
 3. Deploy the web application:
-    cp target/switchyard-quickstart-demo-helpdesk-webapp.war <path-to>/switchyard-as7-0.5/standalone/deployments/
+    mvn jboss-as:deploy
 4. Start the Human Task server:
     mvn exec:java -Dexec.args="start.taskserver"
 5. In a web browser window, use the web application:

--- a/demos/multiApp/order-consumer/README.md
+++ b/demos/multiApp/order-consumer/README.md
@@ -20,7 +20,7 @@ JBoss AS 7
 5. Deploy JMS Queue
     cp src/test/resources/switchyard-quickstart-demo-multi-order-consumer-hornetq-jms.xml ${AS7}/standalone/deployments
 6. Deploy the quickstart
-    cp target/switchyard-quickstart-demo-multi-order-consumer.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 7. Execute the test client
     mvn exec:java
 8. Check the server console for output from the service.

--- a/demos/policy-security/Readme.md
+++ b/demos/policy-security/Readme.md
@@ -25,12 +25,12 @@ Running the quickstart
 4. Start JBoss AS 7 in standalone mode:
     ./standalone.sh
 5. Deploy the quickstart
-    cp target/switchyard-quickstart-demo-policy-security.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 6. Execute the test
     See "Options" section below.
 7. Check the server console for output from the service.
 8. Undeploy the application
-    rm ${AS7}/standalone/deployments/switchyard-quickstart-demo-policy-security-{version}.jar.deployed
+    mvn jboss-as:undeploy
 
 
 Options

--- a/demos/policy-transaction/Readme.md
+++ b/demos/policy-transaction/Readme.md
@@ -22,14 +22,14 @@ Running the quickstart
 5. Deploy JMS Queue
     cp src/test/resources/switchyard-quickstart-demo-policy-transaction-hornetq-jms.xml ${AS7}/standalone/deployments
 6. Deploy the quickstart
-    cp target/switchyard-quickstarts-policy-transaction.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 7. Execute HornetQClient
     mvn exec:java
 8. Check the server console for output from the service.  With the default
    configuration of the quickstart, you should see the output below in the
    AS server.log.
 9. Undeploy the application
-    rm ${AS7}/standalone/deployments/switchyard-quickstart-demo-policy-transaction-{version}.jar.deployed
+    mvn jboss-as:undeploy
     rm ${AS7}/standalone/deployments/switchyard-quickstart-demo-policy-transaction-hornetq-jms.xml
 
 ```

--- a/hornetq-binding/Readme.md
+++ b/hornetq-binding/Readme.md
@@ -19,7 +19,7 @@ JBoss AS 7
 5. Deploy JMS Queue
     cp src/test/resources/switchyard-quickstart-hornetq-binding-hornetq-jms.xml ${AS7}/standalone/deployments
 6. Deploy the quickstart
-    cp target/switchyard-quickstarts-hornetq-binding.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 7. Execute HornetQClient
     mvn exec:java
 8. Check the server console for output from the service.

--- a/http-binding/Readme.md
+++ b/http-binding/Readme.md
@@ -28,7 +28,7 @@ JBoss AS 7
 </pre>
 3. Deploy the quickstart
 <pre>
-    cp target/switchyard-quickstart-http-binding.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 </pre>
 4. Open a console windows and type  
 <pre>

--- a/jca-inflow-hornetq/Readme.md
+++ b/jca-inflow-hornetq/Readme.md
@@ -17,7 +17,7 @@ JBoss AS 7
 5. Deploy JMS Queue
     cp src/test/resources/switchyard-quickstart-jca-inflow-hornetq-jms.xml ${AS7}/standalone/deployments
 6. Deploy the quickstart
-    cp target/switchyard-quickstarts-jca-inflow-hornetq.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 7. Execute HornetQClient
     mvn exec:java
 8. Check the server console for output from the service.

--- a/jca-outbound-hornetq/Readme.md
+++ b/jca-outbound-hornetq/Readme.md
@@ -20,7 +20,7 @@ JBoss AS 7
 5. Deploy JMS Queue
     cp src/test/resources/switchyard-quickstart-jca-outbound-hornetq-jms.xml ${AS7}/standalone/deployments
 6. Deploy the quickstart
-    cp target/switchyard-quickstart-jca-outbound-hornetq.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 7. Execute HornetQClient
     mvn exec:java
 8. Check the output from the client.

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,11 @@
                     </systemProperties>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <version>7.1.1.Final</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/rest-binding/Readme.md
+++ b/rest-binding/Readme.md
@@ -31,7 +31,7 @@ JBoss AS 7
 </pre>
 3. Deploy the quickstart
 <pre>
-    cp target/switchyard-quickstart-rest-binding.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 </pre>
 4. Open a console windows and type  
 <pre>

--- a/transform-jaxb/Readme.md
+++ b/transform-jaxb/Readme.md
@@ -21,7 +21,7 @@ JBoss AS 7
 2. Start JBoss AS 7 with the standalone-preview.xml :
     ./standalone.sh 
 3. Deploy the Quickstart :
-    cp target/switchyard-quickstart-transform-jaxb.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 4. Submit a request with your preferred SOAP client - src/test/resources/xml contains sample 
    requests and the responses that you should see
 

--- a/transform-smooks/Readme.md
+++ b/transform-smooks/Readme.md
@@ -23,7 +23,7 @@ JBoss AS 7
 2. Start JBoss AS 7 in standalone mode:
     ./standalone
 3. Deploy the Quickstart : 
-    cp target/switchyard-quickstart-transform-smooks.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 4. Run the test from Maven :
     mvn -Dtest=ServiceTransformationTest test
 

--- a/transform-xslt/Readme.md
+++ b/transform-xslt/Readme.md
@@ -19,7 +19,7 @@ JBoss AS 7
 2. Start JBoss AS 7 in standalone mode:
     ./standalone
 3. Deploy the Quickstart : 
-    cp target/switchyard-quickstart-transform-xslt.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 4. Submit a webservice request to invoke the SOAP gateway.  There are a number of ways to do this :
       - Submit a request with your preferred SOAP client - src/test/resources/xml contains 
          sample requests and the responses that you should see

--- a/validate-xml/Readme.md
+++ b/validate-xml/Readme.md
@@ -21,7 +21,7 @@ JBoss AS 7
 2. Start JBoss AS 7 in standalone mode:
     ./standalone
 3. Deploy the Quickstart : 
-    cp target/switchyard-quickstart-validate-xml.jar ${AS7}/standalone/deployments
+    mvn jboss-as:deploy
 4. Submit a webservice request to invoke the SOAP gateway.  There are a number of ways to do this :
       - Submit a request with your preferred SOAP client - src/test/resources/xml contains 
          sample requests and the responses that you should see


### PR DESCRIPTION
https://issues.jboss.org/browse/SWITCHYARD-968
Added jboss-as-maven-plugin to the parent pom.xml and modified the description of "Deploy the quickstart" step to "mvn jboss-as:deploy" in each Readme.md
