### PR TITLE
SWITCHYARD-751 ServiceBinding and reference with same name creates problems

### DIFF
--- a/camel-netty-binding/src/test/java/org/switchyard/quickstarts/camel/netty/binding/CamelNettyBindingTest.java
+++ b/camel-netty-binding/src/test/java/org/switchyard/quickstarts/camel/netty/binding/CamelNettyBindingTest.java
@@ -53,7 +53,7 @@ public class CamelNettyBindingTest {
 	private final static String PAYLOAD = "Keith";;
 
     @Test
-    public void sendTextMessageThroughTcp() throws Exception {    
+    public void sendTextMessageThroughTcp() throws Exception {
         // replace existing implementation for testing purposes
         _testKit.removeService("GreetingService");
         final MockHandler greetingService = _testKit.registerInOnlyService("GreetingService");
@@ -62,11 +62,12 @@ public class CamelNettyBindingTest {
         DataOutputStream outputStream = new DataOutputStream(clientSocket.getOutputStream());
         // lets write payload directly as bytes to avoid encoding mismatches
         outputStream.write(PAYLOAD.getBytes());
+        outputStream.flush();
 
         // sleep a bit to receive message on camel side
-        Thread.sleep(100);
         clientSocket.close();
 
+        greetingService.waitForOKMessage();
         final LinkedBlockingQueue<Exchange> recievedMessages = greetingService.getMessages();
         assertThat(recievedMessages, is(notNullValue()));
         final Exchange recievedExchange = recievedMessages.iterator().next();
@@ -86,9 +87,9 @@ public class CamelNettyBindingTest {
         clientSocket.send(packet);
 
         // sleep a bit to receive message on camel side
-        Thread.sleep(100);
         clientSocket.close();
 
+        greetingService.waitForOKMessage();
         final LinkedBlockingQueue<Exchange> recievedMessages = greetingService.getMessages();
         assertThat(recievedMessages, is(notNullValue()));
         final Exchange recievedExchange = recievedMessages.iterator().next();

--- a/http-binding/src/main/java/org/switchyard/quickstarts/http/binding/QuoteServiceImpl.java
+++ b/http-binding/src/main/java/org/switchyard/quickstarts/http/binding/QuoteServiceImpl.java
@@ -19,8 +19,6 @@
 
 package org.switchyard.quickstarts.http.binding;
 
-import static org.switchyard.component.http.composer.HttpComposition.HTTP_HEADER;
-
 import javax.inject.Inject;
 
 import org.switchyard.component.bean.Reference;

--- a/http-binding/src/main/java/org/switchyard/quickstarts/http/binding/SymbolServiceImpl.java
+++ b/http-binding/src/main/java/org/switchyard/quickstarts/http/binding/SymbolServiceImpl.java
@@ -19,8 +19,6 @@
 
 package org.switchyard.quickstarts.http.binding;
 
-import java.util.List;
-
 import javax.inject.Inject;
 
 import org.switchyard.Context;

--- a/http-binding/src/main/resources/META-INF/switchyard.xml
+++ b/http-binding/src/main/resources/META-INF/switchyard.xml
@@ -19,9 +19,9 @@
     xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
     xmlns:bean="urn:switchyard-component-bean:config:1.0">
 
-    <sca:composite name="StockService" targetNamespace="urn:switchyard-quickstart:http-binding:1.0">
+    <sca:composite name="http-binding" targetNamespace="urn:switchyard-quickstart:http-binding:1.0">
 
-        <sca:service name="QuoteService" promote="StockService/QuoteService">
+        <sca:service name="QuoteService" promote="QuoteService/QuoteService">
             <http:binding.http>
                 <selector:operationSelector operationName="getPrice"/>
                 <http:contextPath>http-binding/quote</http:contextPath>
@@ -37,30 +37,13 @@
         </sca:service>
 
         <sca:reference name="Symbol" promote="StockService/SymbolService" multiplicity="1..1">
+            <!-- External reference which allows to call SymbolService using http client -->
             <http:binding.http>
                 <http:address>http://localhost:8080/http-binding/symbol</http:address>
                 <http:method>POST</http:method>
                 <http:contentType>text/plain</http:contentType>
             </http:binding.http>
         </sca:reference>
-
-        <sca:component name="StockService">
-            <bean:implementation.bean class="org.switchyard.quickstarts.http.binding.QuoteServiceImpl"/>
-            <sca:service name="QuoteService">
-                <sca:interface.java interface="org.switchyard.quickstarts.http.binding.QuoteService"/>
-            </sca:service>
-            <!-- If you set this interface same as the one in the other service then the SwitchYard Service will be invoked directly -->
-            <sca:reference name="SymbolService">
-                <sca:interface.java interface="org.switchyard.quickstarts.http.binding.Symbol"/>
-            </sca:reference>
-        </sca:component>
-
-        <sca:component name="SymbolService">
-            <bean:implementation.bean class="org.switchyard.quickstarts.http.binding.SymbolServiceImpl"/>
-            <sca:service name="SymbolService">
-                <sca:interface.java interface="org.switchyard.quickstarts.http.binding.SymbolService"/>
-            </sca:service>
-        </sca:component>
 
     </sca:composite>
 <!--

--- a/http-binding/src/test/java/org/switchyard/quickstarts/http/binding/HttpBindingTest.java
+++ b/http-binding/src/test/java/org/switchyard/quickstarts/http/binding/HttpBindingTest.java
@@ -43,6 +43,8 @@ import org.switchyard.transform.config.model.TransformSwitchYardScanner;
 @RunWith(SwitchYardRunner.class)
 public class HttpBindingTest {
 
+    private static final String BASE_URL = "http://localhost:8080/http-binding";
+
     private HTTPMixIn http;
 
     /**
@@ -78,6 +80,4 @@ public class HttpBindingTest {
         String response = http.sendString(BASE_URL + "/symbol", "requestInfo", HTTPMixIn.HTTP_POST);
         Assert.assertTrue(response.indexOf("HttpRequestInfo [authType=null, characterEncoding=UTF-8, contentType=text/xml;charset=UTF-8, contextPath=/http-binding/symbol") == 0);
     }
-
-    private static final String BASE_URL = "http://localhost:8080/http-binding";
 }

--- a/jca-inflow-hornetq/src/main/resources/META-INF/switchyard.xml
+++ b/jca-inflow-hornetq/src/main/resources/META-INF/switchyard.xml
@@ -1,12 +1,12 @@
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
-		    xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
-           xmlns:jca="urn:switchyard-component-jca:config:1.0"
-           xmlns:selector="urn:switchyard-component-common-selector:config:1.0"
-		    xmlns:bean="urn:switchyard-component-bean:config:1.0">
-            
+            xmlns:sca="http://docs.oasis-open.org/ns/opencsa/sca/200912" 
+            xmlns:jca="urn:switchyard-component-jca:config:1.0"
+            xmlns:selector="urn:switchyard-component-common-selector:config:1.0"
+            xmlns:bean="urn:switchyard-component-bean:config:1.0">
+
     <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="jca-inflow-hornetq" targetNamespace="urn:switchyard-quickstart:jca-inflow-hornetq:0.1.0">
-    
-        <service name="GreetingService" promote="GreetingComponent/GreetingService">
+
+        <service name="GreetingService" promote="GreetingService/GreetingService">
             <interface.java interface="org.switchyard.quickstarts.jca.inflow.GreetingGateway"/>
             <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">
                <selector:operationSelector.xpath expression="//person/language"/>
@@ -25,15 +25,8 @@
                </inboundInteraction>
             </binding.jca>
         </service>
-        
-        <component name="GreetingComponent">
-            <bean:implementation.bean class="org.switchyard.quickstarts.jca.inflow.GreetingServiceBean"/>
-            <sca:service name="GreetingService">
-                <sca:interface.java interface="org.switchyard.quickstarts.jca.inflow.GreetingService"/>
-            </sca:service>
-        </component>
     </composite>
-        
+
     <transforms xmlns:xform="urn:switchyard-config:transform:1.0">
         <xform:transform.jaxb 
             from="{urn:switchyard-quickstart:jca-inflow-hornetq:0.1.0}person" 

--- a/jca-inflow-hornetq/src/test/java/org/switchyard/quickstarts/jca/inflow/JCAInflowBindingTest.java
+++ b/jca-inflow-hornetq/src/test/java/org/switchyard/quickstarts/jca/inflow/JCAInflowBindingTest.java
@@ -74,9 +74,9 @@ public class JCAInflowBindingTest {
         final TextMessage message = _hqMixIn.getJMSSession().createTextMessage();
         message.setText(PAYLOAD);
         producer.send(message);
-        
-        Thread.sleep(1000);
-        
+
+        greetingService.waitForOKMessage();
+
         final Exchange recievedExchange = greetingService.getMessages().iterator().next();
         Assert.assertEquals(PAYLOAD, recievedExchange.getMessage().getContent(String.class));
     }

--- a/jca-outbound-hornetq/src/main/resources/META-INF/switchyard.xml
+++ b/jca-outbound-hornetq/src/main/resources/META-INF/switchyard.xml
@@ -8,7 +8,7 @@
             
     <sca:composite name="jca-outbound-hornetq" targetNamespace="urn:switchyard-quickstart:jca-outbound-hornetq:0.1.0">
     
-        <sca:service name="OrderService" promote="OrderComponent/OrderService">
+        <sca:service name="OrderService" promote="OrderService/OrderService">
             <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">
                <selector:operationSelector operationName="process"/>
                <inboundConnection>
@@ -27,7 +27,7 @@
             </binding.jca>
         </sca:service>
 
-        <sca:reference name="ShippingReference" promote="OrderComponent/ShippingReference" multiplicity="1..1">
+        <sca:reference name="ShippingReference" promote="OrderService/ShippingReference" multiplicity="1..1">
             <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">
                <outboundConnection>
                    <resourceAdapter name="hornetq-ra.rar"/>
@@ -40,7 +40,7 @@
                </outboundInteraction>
             </binding.jca>
         </sca:reference>
-        <sca:reference name="FillingStockReference" promote="OrderComponent/FillingStockReference" multiplicity="1..1">
+        <sca:reference name="FillingStockReference" promote="OrderService/FillingStockReference" multiplicity="1..1">
             <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">
                <outboundConnection>
                    <resourceAdapter name="hornetq-ra.rar"/>
@@ -53,18 +53,6 @@
                </outboundInteraction>
             </binding.jca>
         </sca:reference>
-        
-        <sca:component name="OrderComponent">
-            <bean:implementation.bean class="org.switchyard.quickstarts.jca.outbound.OrderServiceBean"/>
-            <sca:service name="OrderService">
-                <sca:interface.java interface="org.switchyard.quickstarts.jca.outbound.OrderService"/>
-            </sca:service>
-            <sca:reference name="ShippingReference">
-                <sca:interface.java interface="org.switchyard.quickstarts.jca.outbound.OrderService"/>
-            </sca:reference>
-            <sca:reference name="FillingStockReference">
-                <sca:interface.java interface="org.switchyard.quickstarts.jca.outbound.OrderService"/>
-            </sca:reference>
-        </sca:component>
+
     </sca:composite>
 </switchyard>


### PR DESCRIPTION
Necessary changes in quickstarts. Fixes in netty quickstarts to avoid timing issues.
