### PR TITLE
SWITCHYARD-1069: Separate picketlink from core security classes

### DIFF
--- a/demos/policy-security-sslsaml/src/main/resources/META-INF/switchyard.xml
+++ b/demos/policy-security-sslsaml/src/main/resources/META-INF/switchyard.xml
@@ -15,6 +15,6 @@
             <handler class="org.switchyard.handlers.MessageTrace" name="MessageTrace"/>
         </handlers>
         -->
-        <security moduleName="saml-validate-token" callbackHandler="org.switchyard.security.callback.STSTokenCallbackHandler"/>
+        <security moduleName="saml-validate-token" callbackHandler="org.switchyard.security.jboss.callback.STSTokenCallbackHandler"/>
     </domain>
 </switchyard>


### PR DESCRIPTION
SWITCHYARD-1069: Separate picketlink from core security classes
https://issues.jboss.org/browse/SWITCHYARD-1069
