### PR TITLE
SWITCHYARD-1084 Add meaningful assertion for policy-transaction demo

### DIFF
--- a/bpel-service/jms_binding/Readme.md
+++ b/bpel-service/jms_binding/Readme.md
@@ -17,16 +17,14 @@ JBoss AS 7
     mvn clean install
 2. Start JBoss AS 7 in standalone-full mode:
     ${AS}/bin/standalone.sh --server-config=standalone-full.xml
-3. Add JMS user using add-user.sh with username=guest, password=guestp, Realm=ApplicationRealm
+3. Add JMS user using add-user.sh with username=guest, password=guestp, Realm=ApplicationRealm, role=guest
     ./add-user.sh
-4. Add a guest role to the user "guest"
-   echo "guest=guest" >> ${AS7}/standalone/configuration/application-roles.properties
-5. Deploy JMS Queue
+4. Deploy JMS Queue
     cp src/test/resources/switchyard-quickstart-bpel-jms-hornetq-jms.xml ${AS7}/standalone/deployments
-6. Deploy the quickstart
+5. Deploy the quickstart
     mvn jboss-as:deploy
-7. Execute HornetQClient
+6. Execute HornetQClient
     mvn exec:java
-8. Watch the command output for the reply message.
+7. Watch the command output for the reply message.
 
 

--- a/camel-jms-binding/Readme.md
+++ b/camel-jms-binding/Readme.md
@@ -15,17 +15,15 @@ JBoss AS 7
     mvn clean install
 2. Start JBoss AS 7 in standalone-full mode:
     ${AS}/bin/standalone.sh --server-config=standalone-full.xml
-3. Add JMS user using add-user.sh with username=guest, password=guestp, Realm=ApplicationRealm
+3. Add JMS user using add-user.sh with username=guest, password=guestp, Realm=ApplicationRealm, role=guest
     ./add-user.sh
-4. Add a guest role to the user "guest"
-   echo "guest=guest" >> ${AS7}/standalone/configuration/application-roles.properties
-5. Deploy JMS Queue
+4. Deploy JMS Queue
     cp src/test/resources/switchyard-quickstart-camel-jms-binding-hornetq-jms.xml ${AS7}/standalone/deployments
-6. Deploy the quickstart
+5. Deploy the quickstart
     mvn jboss-as:deploy
-7. Execute HornetQClient
+6. Execute HornetQClient
     mvn exec:java
-8. Check the server console for output from the service.
+7. Check the server console for output from the service.
 
 ## Further Reading
 

--- a/demos/policy-transaction/Readme.md
+++ b/demos/policy-transaction/Readme.md
@@ -23,20 +23,18 @@ Running the quickstart
     mvn clean install
 2. Start JBoss AS 7 in standalone-full mode:
     ./standalone --server-config=standalone-full.xml
-3. Add JMS user using add-user.sh with username=guest, password=guestp, Realm=ApplicationRealm
+3. Add JMS user using add-user.sh with username=guest, password=guestp, Realm=ApplicationRealm, role=guest
     ./add-user.sh
-4. Add a guest role to the user "guest"
-   echo "guest=guest" >> ${AS7}/standalone/configuration/application-roles.properties
-5. Deploy JMS Queue
+4. Deploy JMS Queue
     cp src/test/resources/switchyard-quickstart-demo-policy-transaction-hornetq-jms.xml ${AS7}/standalone/deployments
-6. Deploy the quickstart
+5. Deploy the quickstart
     mvn jboss-as:deploy
-7. Execute HornetQClient
+6. Execute HornetQClient
     mvn exec:java
-8. Check the server console for output from the service.  With the default
+7. Check the server console for output from the service.  With the default
    configuration of the quickstart, you should see the output below in the
    AS server.log.
-9. Undeploy the application
+8. Undeploy the application
     mvn jboss-as:undeploy
     rm ${AS7}/standalone/deployments/switchyard-quickstart-demo-policy-transaction-hornetq-jms.xml
 

--- a/demos/policy-transaction/pom.xml
+++ b/demos/policy-transaction/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.switchyard.components</groupId>
-            <artifactId>switchyard-component-camel-core</artifactId>
+            <artifactId>switchyard-component-jca</artifactId>
         </dependency>
         <dependency>
             <groupId>org.switchyard.components</groupId>
@@ -51,6 +51,21 @@
         <dependency>
             <groupId>org.switchyard.components</groupId>
             <artifactId>switchyard-component-test-mixin-hornetq</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.switchyard.components</groupId>
+            <artifactId>switchyard-component-test-mixin-cdi</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.switchyard.components</groupId>
+            <artifactId>switchyard-component-test-mixin-jca</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/demos/policy-transaction/src/main/java/org/switchyard/quickstarts/demo/policy/transaction/StoreService.java
+++ b/demos/policy-transaction/src/main/java/org/switchyard/quickstarts/demo/policy/transaction/StoreService.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010-2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details. You should have received a copy of the GNU Lesser General Public
+ * License, v.2.1 along with this distribution; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+package org.switchyard.quickstarts.demo.policy.transaction;
+
+/**
+ * Store Service.
+ */
+public interface StoreService {
+    
+    /**
+     * Store a message.
+     * @param message message
+     */
+    void store(String message);
+}

--- a/demos/policy-transaction/src/main/java/org/switchyard/quickstarts/demo/policy/transaction/TaskAServiceBean.java
+++ b/demos/policy-transaction/src/main/java/org/switchyard/quickstarts/demo/policy/transaction/TaskAServiceBean.java
@@ -19,11 +19,13 @@
 
 package org.switchyard.quickstarts.demo.policy.transaction;
 
+import javax.inject.Inject;
 import javax.naming.InitialContext;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 
 import org.switchyard.annotations.Requires;
+import org.switchyard.component.bean.Reference;
 import org.switchyard.component.bean.Service;
 import org.switchyard.policy.TransactionPolicy;
 
@@ -43,6 +45,9 @@ public class TaskAServiceBean implements TaskAService {
     // counts the number of times a rollback has occurred
     private int _rollbackCounter = 0;
     
+    @Inject @Reference("StoreAService") @Requires(transaction=TransactionPolicy.PROPAGATES_TRANSACTION)
+    private StoreService _storeA;
+    
     @Override
     public final void doTask(final String command) {
         
@@ -58,6 +63,8 @@ public class TaskAServiceBean implements TaskAService {
             return;
         }
 
+        _storeA.store(command);
+        
         if (command.contains(ROLLBACK)) {
             try {
                 if (++_rollbackCounter % 4 != 0) {

--- a/demos/policy-transaction/src/main/java/org/switchyard/quickstarts/demo/policy/transaction/TaskBServiceBean.java
+++ b/demos/policy-transaction/src/main/java/org/switchyard/quickstarts/demo/policy/transaction/TaskBServiceBean.java
@@ -19,11 +19,13 @@
 
 package org.switchyard.quickstarts.demo.policy.transaction;
 
+import javax.inject.Inject;
 import javax.naming.InitialContext;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 
 import org.switchyard.annotations.Requires;
+import org.switchyard.component.bean.Reference;
 import org.switchyard.component.bean.Service;
 import org.switchyard.policy.TransactionPolicy;
 
@@ -43,6 +45,9 @@ public class TaskBServiceBean implements TaskBService {
     // counts the number of times a rollback has occurred
     private int _rollbackCounter = 0;
     
+    @Inject @Reference("StoreBService") @Requires(transaction=TransactionPolicy.SUSPENDS_TRANSACTION)
+    private StoreService _storeB;
+    
     @Override
     public final void doTask(final String command) {
         
@@ -58,6 +63,8 @@ public class TaskBServiceBean implements TaskBService {
             return;
         }
 
+        _storeB.store(command);
+        
         if (command.contains(ROLLBACK)) {
             try {
                 if (++_rollbackCounter % 4 != 0) {

--- a/demos/policy-transaction/src/main/java/org/switchyard/quickstarts/demo/policy/transaction/TaskCServiceBean.java
+++ b/demos/policy-transaction/src/main/java/org/switchyard/quickstarts/demo/policy/transaction/TaskCServiceBean.java
@@ -19,11 +19,13 @@
 
 package org.switchyard.quickstarts.demo.policy.transaction;
 
+import javax.inject.Inject;
 import javax.naming.InitialContext;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
 
 import org.switchyard.annotations.Requires;
+import org.switchyard.component.bean.Reference;
 import org.switchyard.component.bean.Service;
 import org.switchyard.policy.TransactionPolicy;
 
@@ -40,6 +42,9 @@ public class TaskCServiceBean implements TaskCService {
 
     private static final String JNDI_TRANSACTION_MANAGER = "java:jboss/TransactionManager";
     
+    @Inject @Reference("StoreCService")
+    private StoreService _storeC;
+    
     @Override
     public final void doTask(final String command) {
         
@@ -51,6 +56,8 @@ public class TaskCServiceBean implements TaskCService {
             print("Failed to get current transcation");
         }
 
+        _storeC.store(command);
+        
         if (t == null) {
             print("No active transaction");
         } else {

--- a/demos/policy-transaction/src/main/resources/META-INF/switchyard.xml
+++ b/demos/policy-transaction/src/main/resources/META-INF/switchyard.xml
@@ -21,15 +21,86 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <switchyard xmlns="urn:switchyard-config:switchyard:1.0"
-    xmlns:core="urn:switchyard-component-camel-core:config:1.0">
+    xmlns:swyd="urn:switchyard-config:switchyard:1.0"
+    xmlns:camel="urn:switchyard-component-camel-core:config:1.0">
 
     <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="policy-transaction" targetNamespace="urn:switchyard-quickstart-demo:policy-transaction:0.1.0">
         <service name="WorkService" promote="WorkService">
             <!-- This binding provides an inbound transaction, satisfying a service requirement for a propagated transaction. -->
-            <core:binding.uri configURI="jms://policyQSTransacted?connectionFactory=%23JmsXA&amp;transactionManager=%23jtaTransactionManager&amp;transacted=true"/>
+            <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">
+               <inboundConnection>
+                   <resourceAdapter name="hornetq-ra.rar">
+                   </resourceAdapter>
+                   <activationSpec>
+                       <property name="destinationType" value="javax.jms.Queue"/>
+                       <property name="destination" value="policyQSTransacted"/>
+                   </activationSpec>
+               </inboundConnection>
+               <inboundInteraction>
+                   <listener>javax.jms.MessageListener</listener>
+                   <endpoint type="org.switchyard.component.jca.endpoint.JMSEndpoint"/>
+                   <transacted>true</transacted>
+               </inboundInteraction>
+            </binding.jca>
             <!-- This binding does *not* provide an inbound transaction, violating a service requirement for a propagated transaction. -->
-            <core:binding.uri configURI="jms://policyQSNonTransacted?connectionFactory=#ConnectionFactory"/>
+            <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">
+               <inboundConnection>
+                   <resourceAdapter name="hornetq-ra.rar">
+                   </resourceAdapter>
+                   <activationSpec>
+                       <property name="destinationType" value="javax.jms.Queue"/>
+                       <property name="destination" value="policyQSNonTransacted"/>
+                   </activationSpec>
+               </inboundConnection>
+               <inboundInteraction>
+                   <listener>javax.jms.MessageListener</listener>
+                   <endpoint type="org.switchyard.component.jca.endpoint.JMSEndpoint"/>
+                   <transacted>false</transacted>
+               </inboundInteraction>
+            </binding.jca>
         </service>
+        
+        <reference name="StoreAService" multiplicity="0..1" promote="TaskAService/StoreAService">
+            <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">
+               <outboundConnection>
+                   <resourceAdapter name="hornetq-ra.rar"/>
+                   <connection jndiName="java:/JmsXA"/>
+               </outboundConnection>
+               <outboundInteraction>
+                   <processor type="org.switchyard.component.jca.processor.JMSProcessor">
+                       <property name="destination" value="queueA"/>
+                   </processor>
+               </outboundInteraction>
+            </binding.jca>
+        </reference>
+
+        <reference name="StoreBService" multiplicity="0..1" promote="TaskBService/StoreBService">
+            <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">
+               <outboundConnection>
+                   <resourceAdapter name="hornetq-ra.rar"/>
+                   <connection jndiName="java:/JmsXA"/>
+               </outboundConnection>
+               <outboundInteraction>
+                   <processor type="org.switchyard.component.jca.processor.JMSProcessor">
+                       <property name="destination" value="queueB"/>
+                   </processor>
+               </outboundInteraction>
+            </binding.jca>
+        </reference>
+
+        <reference name="StoreCService" multiplicity="0..1" promote="TaskCService/StoreCService">
+            <binding.jca xmlns="urn:switchyard-component-jca:config:1.0">
+               <outboundConnection>
+                   <resourceAdapter name="hornetq-ra.rar"/>
+                   <connection jndiName="java:/JmsXA"/>
+               </outboundConnection>
+               <outboundInteraction>
+                   <processor type="org.switchyard.component.jca.processor.JMSProcessor">
+                       <property name="destination" value="queueC"/>
+                   </processor>
+               </outboundInteraction>
+            </binding.jca>
+        </reference>
     </composite>
 
     <!-- Uncomment this section to trace message exchange activity

--- a/demos/policy-transaction/src/test/java/org/switchyard/quickstarts/demo/policy/transaction/JmsBindingTest.java
+++ b/demos/policy-transaction/src/test/java/org/switchyard/quickstarts/demo/policy/transaction/JmsBindingTest.java
@@ -1,0 +1,170 @@
+/*
+ * JBoss, Home of Professional Open Source Copyright 2009, Red Hat Middleware
+ * LLC, and individual contributors by the @authors tag. See the copyright.txt
+ * in the distribution for a full listing of individual contributors.
+ * 
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.switchyard.quickstarts.demo.policy.transaction;
+
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.component.bean.config.model.BeanSwitchYardScanner;
+import org.switchyard.test.BeforeDeploy;
+import org.switchyard.test.SwitchYardRunner;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+import org.switchyard.component.test.mixins.hornetq.HornetQMixIn;
+import org.switchyard.component.test.mixins.jca.JCAMixIn;
+import org.switchyard.component.test.mixins.jca.ResourceAdapterConfig;
+
+/**
+ * Functional test for a policy-transaction demo quickstart.
+ */
+@RunWith(SwitchYardRunner.class)
+@SwitchYardTestCaseConfig(
+        config = SwitchYardTestCaseConfig.SWITCHYARD_XML,
+        mixins = {CDIMixIn.class, HornetQMixIn.class, JCAMixIn.class},
+        scanners = BeanSwitchYardScanner.class)
+public class JmsBindingTest {
+    private static final String QUEUE_IN = "policyQSTransacted";
+    private static final String QUEUE_IN_NOTX = "policyQSNonTransacted";
+    private static final String QUEUE_OUT_A = "queueA";
+    private static final String QUEUE_OUT_B = "queueB";
+    private static final String QUEUE_OUT_C = "queueC";
+    
+    private HornetQMixIn _hqMixIn;
+    private JCAMixIn _jcaMixIn;
+    
+    @BeforeDeploy
+    public void before() {
+        ResourceAdapterConfig ra = new ResourceAdapterConfig(ResourceAdapterConfig.ResourceAdapterType.HORNETQ);
+        _jcaMixIn.deployResourceAdapters(ra);
+    }
+    
+    @After
+    public void after() throws Exception {
+        Session session = _hqMixIn.createJMSSession();
+        MessageConsumer consumer = session.createConsumer(HornetQMixIn.getJMSQueue(QUEUE_OUT_A));
+        while (consumer.receive(1000) != null);
+        consumer = session.createConsumer(HornetQMixIn.getJMSQueue(QUEUE_OUT_B));
+        while (consumer.receive(1000) != null);
+        consumer = session.createConsumer(HornetQMixIn.getJMSQueue(QUEUE_OUT_C));
+        while (consumer.receive(1000) != null);
+        session.close();
+    }
+    
+    /**
+     * Triggers the 'WorkService' by sending a HornetQ Message to the 'policyQSTransacted' queue.
+     */
+    @Test
+    public void testRollbackA() throws Exception {
+        String command = "rollback.A";
+        
+        Session session = _hqMixIn.getJMSSession();
+        final MessageProducer producer = session.createProducer(HornetQMixIn.getJMSQueue(QUEUE_IN));
+        final TextMessage message = _hqMixIn.getJMSSession().createTextMessage();
+        message.setText(command);
+        producer.send(message);
+        session.close();
+        
+        session = _hqMixIn.createJMSSession();
+        MessageConsumer consumer = session.createConsumer(HornetQMixIn.getJMSQueue(QUEUE_OUT_A));
+        ObjectMessage msg = ObjectMessage.class.cast(consumer.receive(30000));
+        Assert.assertEquals(command, msg.getObject());
+        Assert.assertNull(consumer.receive(1000));
+
+        consumer = session.createConsumer(HornetQMixIn.getJMSQueue(QUEUE_OUT_B));
+        msg = ObjectMessage.class.cast(consumer.receive(1000));
+        Assert.assertEquals(command, msg.getObject());
+        msg = ObjectMessage.class.cast(consumer.receive(1000));
+        Assert.assertEquals(command, msg.getObject());
+        msg = ObjectMessage.class.cast(consumer.receive(1000));
+        Assert.assertEquals(command, msg.getObject());
+        msg = ObjectMessage.class.cast(consumer.receive(1000));
+        Assert.assertEquals(command, msg.getObject());
+        Assert.assertNull(consumer.receive(1000));
+        
+        consumer = session.createConsumer(HornetQMixIn.getJMSQueue(QUEUE_OUT_C));
+        msg = ObjectMessage.class.cast(consumer.receive(1000));
+        Assert.assertEquals(command, msg.getObject());
+        msg = ObjectMessage.class.cast(consumer.receive(1000));
+        Assert.assertEquals(command, msg.getObject());
+        msg = ObjectMessage.class.cast(consumer.receive(1000));
+        Assert.assertEquals(command, msg.getObject());
+        msg = ObjectMessage.class.cast(consumer.receive(1000));
+        Assert.assertEquals(command, msg.getObject());
+        Assert.assertNull(consumer.receive(1000));
+        session.close();
+    }
+    
+    @Test
+    public void testRollbackB() throws Exception {
+        String command = "rollback.B";
+        
+        Session session = _hqMixIn.getJMSSession();
+        final MessageProducer producer = session.createProducer(HornetQMixIn.getJMSQueue(QUEUE_IN));
+        final TextMessage message = _hqMixIn.getJMSSession().createTextMessage();
+        message.setText(command);
+        producer.send(message);
+        session.close();
+        
+        session = _hqMixIn.createJMSSession();
+        MessageConsumer consumer = session.createConsumer(HornetQMixIn.getJMSQueue(QUEUE_OUT_A));
+        ObjectMessage msg = ObjectMessage.class.cast(consumer.receive(1000));
+        Assert.assertEquals(command, msg.getObject());
+        Assert.assertNull(consumer.receive(1000));
+
+        consumer = session.createConsumer(HornetQMixIn.getJMSQueue(QUEUE_OUT_B));
+        msg = ObjectMessage.class.cast(consumer.receive(1000));
+        Assert.assertEquals(command, msg.getObject());
+        Assert.assertNull(consumer.receive(1000));
+        
+        consumer = session.createConsumer(HornetQMixIn.getJMSQueue(QUEUE_OUT_C));
+        msg = ObjectMessage.class.cast(consumer.receive(1000));
+        Assert.assertEquals(command, msg.getObject());
+        Assert.assertNull(consumer.receive(1000));
+        session.close();
+    }
+    
+    @Test
+    public void testNonTransacted() throws Exception {
+        String command = "rollback.A";
+        
+        Session session = _hqMixIn.getJMSSession();
+        final MessageProducer producer = session.createProducer(HornetQMixIn.getJMSQueue(QUEUE_IN_NOTX));
+        final TextMessage message = _hqMixIn.getJMSSession().createTextMessage();
+        message.setText(command);
+        producer.send(message);
+        session.close();
+        
+        session = _hqMixIn.createJMSSession();
+        MessageConsumer consumer = session.createConsumer(HornetQMixIn.getJMSQueue(QUEUE_OUT_A));
+        Assert.assertNull(consumer.receive(1000));
+        consumer = session.createConsumer(HornetQMixIn.getJMSQueue(QUEUE_OUT_B));
+        Assert.assertNull(consumer.receive(1000));
+        consumer = session.createConsumer(HornetQMixIn.getJMSQueue(QUEUE_OUT_C));
+        Assert.assertNull(consumer.receive(1000));
+    }
+}

--- a/demos/policy-transaction/src/test/resources/hornetq-configuration.xml
+++ b/demos/policy-transaction/src/test/resources/hornetq-configuration.xml
@@ -1,0 +1,32 @@
+ <configuration xmlns="urn:hornetq">
+               
+	<paging-directory>target/data/paging</paging-directory>
+	<bindings-directory>target/data/bindings</bindings-directory>
+	<persistence-enabled>false</persistence-enabled>
+	<journal-directory>target/data/journal</journal-directory>
+	<journal-min-files>10</journal-min-files>
+	<large-messages-directory>target/data/large-messages</large-messages-directory>
+	<security-enabled>false</security-enabled>
+
+	<connectors>
+		<connector name="invm-connector">
+			<factory-class>org.hornetq.core.remoting.impl.invm.InVMConnectorFactory</factory-class>
+		</connector>
+		<connector name="netty-connector">
+	         <factory-class>org.hornetq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
+	         <param key="port" value="5545"/>
+                </connector>
+	</connectors>
+
+	<acceptors>
+		<acceptor name="invm-acceptor">
+			<factory-class>org.hornetq.core.remoting.impl.invm.InVMAcceptorFactory</factory-class>
+		</acceptor>
+		<acceptor name="netty-acceptor">
+			<factory-class>org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
+			<param key="port" value="5545"/>
+		</acceptor>
+	</acceptors>
+	
+</configuration>
+ 

--- a/demos/policy-transaction/src/test/resources/hornetq-jms.xml
+++ b/demos/policy-transaction/src/test/resources/hornetq-jms.xml
@@ -1,0 +1,29 @@
+<configuration xmlns="urn:hornetq">
+
+   <connection-factory name="ConnectionFactory">
+      <connectors>
+        <connector-ref connector-name="invm-connector"/>
+      </connectors>
+      
+      <entries>
+         <entry name="ConnectionFactory"/>
+      </entries>
+   </connection-factory>
+   
+   <queue name="policyQSTransacted">
+      <entry name="policyQSTransacted"/>
+   </queue>
+   <queue name="policyQSNonTransacted">
+      <entry name="policyQSNonTransacted"/>
+   </queue>
+   <queue name="queueA">
+      <entry name="queueA"/>
+   </queue>
+   <queue name="queueB">
+      <entry name="queueB"/>
+   </queue>
+   <queue name="queueC">
+      <entry name="queueC"/>
+   </queue>
+    
+</configuration>

--- a/demos/policy-transaction/src/test/resources/switchyard-quickstart-demo-policy-transaction-hornetq-jms.xml
+++ b/demos/policy-transaction/src/test/resources/switchyard-quickstart-demo-policy-transaction-hornetq-jms.xml
@@ -3,10 +3,19 @@
     <hornetq-server>
         <jms-destinations>
             <jms-queue name="policyQSTransacted">
-                <entry name="queue/policyQSTransacted"/>
+                <entry name="policyQSTransacted"/>
             </jms-queue>
             <jms-queue name="policyQSNonTransacted">
-                <entry name="queue/policyQSNonTransacted"/>
+                <entry name="policyQSNonTransacted"/>
+            </jms-queue>
+            <jms-queue name="queueA">
+                <entry name="queueA"/>
+            </jms-queue>
+            <jms-queue name="queueB">
+                <entry name="queueB"/>
+            </jms-queue>
+            <jms-queue name="queueC">
+                <entry name="queueC"/>
             </jms-queue>
          </jms-destinations>
     </hornetq-server>

--- a/hornetq-binding/Readme.md
+++ b/hornetq-binding/Readme.md
@@ -12,10 +12,8 @@ JBoss AS 7
     mvn clean install
 2. Start JBoss AS 7 in standalone-full mode:
      ./standalone.sh -server-config standalone-full.xml
-3. Add JMS user using add-user.sh with username=guest, password=guestp, Realm=ApplicationRealm
+3. Add JMS user using add-user.sh with username=guest, password=guestp, Realm=ApplicationRealm, role=guest
     ./add-user.sh
-4. Add a guest role to the user "guest"
-   echo "guest=guest" >> ${AS7}/standalone/configuration/application-roles.properties
 5. Deploy JMS Queue
     cp src/test/resources/switchyard-quickstart-hornetq-binding-hornetq-jms.xml ${AS7}/standalone/deployments
 6. Deploy the quickstart

--- a/jca-inflow-hornetq/Readme.md
+++ b/jca-inflow-hornetq/Readme.md
@@ -15,18 +15,15 @@ JBoss AS 7
     mvn clean install
 2. Start JBoss AS 7 in standalone-full mode:
      ./standalone.sh -server-config standalone-full.xml
-3. Add JMS user using add-user.sh with username=guest, password=guestp, Realm=ApplicationRealm
+3. Add JMS user using add-user.sh with username=guest, password=guestp, Realm=ApplicationRealm, role=guest
     ./add-user.sh
-4. Add a guest role to the user "guest"
-   echo "" >> ${AS7}/standalone/configuration/application-roles.properties
-   echo "guest=guest" >> ${AS7}/standalone/configuration/application-roles.properties
-5. Deploy JMS Queue
+4. Deploy JMS Queue
     cp src/test/resources/switchyard-quickstart-jca-inflow-hornetq-jms.xml ${AS7}/standalone/deployments
-6. Deploy the quickstart
+5. Deploy the quickstart
     mvn jboss-as:deploy
-7. Execute HornetQClient
+6. Execute HornetQClient
     mvn exec:java
-8. Check the server console for output from the service.
+7. Check the server console for output from the service.
 
 Expected Results
 ================

--- a/jca-inflow-hornetq/src/test/java/org/switchyard/quickstarts/jca/inflow/HornetQClient.java
+++ b/jca-inflow-hornetq/src/test/java/org/switchyard/quickstarts/jca/inflow/HornetQClient.java
@@ -36,7 +36,7 @@ import org.switchyard.component.test.mixins.hornetq.HornetQMixIn;
  */
 public final class HornetQClient {
     
-    private static final String QUEUE = "GreetingServiceQueue";
+    private static final String QUEUE = "JCAInflowGreetingServiceQueue";
     private static final String USER = "guest";
     private static final String PASSWD = "guestp";
     

--- a/jca-outbound-hornetq/Readme.md
+++ b/jca-outbound-hornetq/Readme.md
@@ -12,18 +12,15 @@ JBoss AS 7
     mvn clean install
 2. Start JBoss AS 7 in standalone-full mode:
      ./standalone.sh -server-config standalone-full.xml
-3. Add JMS user using add-user.sh with username=guest, password=guestp, Realm=ApplicationRealm
+3. Add JMS user using add-user.sh with username=guest, password=guestp, Realm=ApplicationRealm, role=guest
     ./add-user.sh
-4. Add a guest role to the user "guest"
-   echo "" >> ${AS7}/standalone/configuration/application-roles.properties
-   echo "guest=guest" >> ${AS7}/standalone/configuration/application-roles.properties
-5. Deploy JMS Queue
+4. Deploy JMS Queue
     cp src/test/resources/switchyard-quickstart-jca-outbound-hornetq-jms.xml ${AS7}/standalone/deployments
-6. Deploy the quickstart
+5. Deploy the quickstart
     mvn jboss-as:deploy
-7. Execute HornetQClient
+6. Execute HornetQClient
     mvn exec:java
-8. Check the output from the client.
+7. Check the output from the client.
 
 Expected Results
 ================


### PR DESCRIPTION
Each sub-task sends a message to its own queue so that we can see if the transaction is committed.

It also fixes
- SWITCHYARD-1159 Queue name in jca-inflow-hornetq test client is incorrect
- SWITCHYARD-1160 update JMS quickstart READMEs - now add-user.sh can add a role correctly
