### PR TITLE
SWITCHYARD-1303 Add service unit tests to bpel quickstarts

### DIFF
--- a/bpel-service/jms_binding/src/test/java/org/switchyard/quickstarts/bpel/service/hello/SayHelloTest.java
+++ b/bpel-service/jms_binding/src/test/java/org/switchyard/quickstarts/bpel/service/hello/SayHelloTest.java
@@ -1,0 +1,53 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2010-2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more 
+ * details. You should have received a copy of the GNU Lesser General Public 
+ * License, v.2.1 along with this distribution; if not, write to the Free 
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  
+ * 02110-1301, USA.
+ */
+
+package org.switchyard.quickstarts.bpel.service.hello;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+import org.switchyard.component.test.mixins.hornetq.HornetQMixIn;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+import org.switchyard.test.SwitchYardTestKit;
+
+@RunWith(SwitchYardRunner.class)
+@SwitchYardTestCaseConfig(
+        config = SwitchYardTestCaseConfig.SWITCHYARD_XML,
+        mixins = {CDIMixIn.class, HornetQMixIn.class})
+public class SayHelloTest {
+    
+    @ServiceOperation("SayHelloService")
+    private Invoker sayHello;
+    
+    private SwitchYardTestKit testKit;
+    
+    @Test
+    public void testHello() throws Exception {
+        String requestTxt = testKit.readResourceString("xml/xml-request.xml");
+        String replyTxt = testKit.readResourceString("xml/xml-response.xml");
+        
+        String replyMsg = sayHello.sendInOut(requestTxt).getContent(String.class);
+        Assert.assertEquals(replyTxt, replyMsg);
+    }
+    
+}

--- a/bpel-service/jms_binding/src/test/resources/xml/xml-request.xml
+++ b/bpel-service/jms_binding/src/test/resources/xml/xml-request.xml
@@ -1,0 +1,3 @@
+<exam:sayHello xmlns:exam="http://www.jboss.org/bpel/examples">
+    <exam:input>Fred</exam:input>
+</exam:sayHello>

--- a/bpel-service/jms_binding/src/test/resources/xml/xml-response.xml
+++ b/bpel-service/jms_binding/src/test/resources/xml/xml-response.xml
@@ -1,0 +1,3 @@
+<sayHelloResponse xmlns="http://www.jboss.org/bpel/examples">
+  <tns:result xmlns:tns="http://www.jboss.org/bpel/examples">Hello Fred</tns:result>
+</sayHelloResponse>

--- a/bpel-service/loan_approval/src/main/resources/risk_assessment.bpel
+++ b/bpel-service/loan_approval/src/main/resources/risk_assessment.bpel
@@ -60,9 +60,9 @@
 			        <assign validate="no" name="AssignName">
 			            <copy>
 			                <from><literal><tns:CheckResponse xmlns:tns="http://example.com/loan-approval/loanService/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-			  <tns:level>low</tns:level>
-			</tns:CheckResponse>
-			</literal></from>
+  <tns:level>low</tns:level>
+</tns:CheckResponse>
+</literal></from>
 			                <to variable="checkResponse" part="parameter"></to>
 			            </copy>
 				    <copy>

--- a/bpel-service/loan_approval/src/test/java/org/switchyard/quickstarts/bpel/service/LoanApprovalTest.java
+++ b/bpel-service/loan_approval/src/test/java/org/switchyard/quickstarts/bpel/service/LoanApprovalTest.java
@@ -1,0 +1,57 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2010-2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more 
+ * details. You should have received a copy of the GNU Lesser General Public 
+ * License, v.2.1 along with this distribution; if not, write to the Free 
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  
+ * 02110-1301, USA.
+ */
+
+package org.switchyard.quickstarts.bpel.service;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+import org.switchyard.test.SwitchYardTestKit;
+
+@RunWith(SwitchYardRunner.class)
+@SwitchYardTestCaseConfig(
+        config = SwitchYardTestCaseConfig.SWITCHYARD_XML,
+        mixins = CDIMixIn.class)
+public class LoanApprovalTest {
+    
+    @ServiceOperation("loanService")
+    private Invoker loanService;
+    
+    private SwitchYardTestKit testKit;
+    
+    @Test
+    public void testLoanApproval1() throws Exception {
+        String requestTxt = testKit.readResourceString("xml/xml-loanreq1.xml");
+        String replyTxt = testKit.readResourceString("xml/xml-loanresp1.xml");
+        
+        String replyMsg = loanService.sendInOut(requestTxt).getContent(String.class);
+        Assert.assertEquals(replyTxt, replyMsg);
+    }
+    
+    @Test(expected=org.switchyard.test.InvocationFaultException.class)
+    public void testLoanApproval2() throws Exception {
+        String requestTxt = testKit.readResourceString("xml/xml-loanreq2.xml");
+        loanService.sendInOut(requestTxt).getContent(String.class);
+    }
+}

--- a/bpel-service/loan_approval/src/test/java/org/switchyard/quickstarts/bpel/service/RiskAssessmentTest.java
+++ b/bpel-service/loan_approval/src/test/java/org/switchyard/quickstarts/bpel/service/RiskAssessmentTest.java
@@ -1,0 +1,57 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2010-2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more 
+ * details. You should have received a copy of the GNU Lesser General Public 
+ * License, v.2.1 along with this distribution; if not, write to the Free 
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  
+ * 02110-1301, USA.
+ */
+
+package org.switchyard.quickstarts.bpel.service;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+import org.switchyard.test.SwitchYardTestKit;
+
+@RunWith(SwitchYardRunner.class)
+@SwitchYardTestCaseConfig(
+        config = SwitchYardTestCaseConfig.SWITCHYARD_XML,
+        mixins = CDIMixIn.class)
+public class RiskAssessmentTest {
+    
+    @ServiceOperation("riskAssessor")
+    private Invoker riskAssessor;
+    
+    private SwitchYardTestKit testKit;
+    
+    @Test
+    public void testRiskAssessment1() throws Exception {
+        String requestTxt = testKit.readResourceString("xml/xml-riskreq1.xml");
+        String replyTxt = testKit.readResourceString("xml/xml-riskresp1.xml");
+        
+        String replyMsg = riskAssessor.sendInOut(requestTxt).getContent(String.class);
+        Assert.assertEquals(replyTxt, replyMsg);
+    }
+    
+    @Test(expected=org.switchyard.test.InvocationFaultException.class)
+    public void testRiskAssessment2() throws Exception {
+        String requestTxt = testKit.readResourceString("xml/xml-riskreq2.xml");
+        riskAssessor.sendInOut(requestTxt).getContent(String.class);
+    }
+}

--- a/bpel-service/loan_approval/src/test/java/org/switchyard/quickstarts/bpel/service/WebServiceTest.java
+++ b/bpel-service/loan_approval/src/test/java/org/switchyard/quickstarts/bpel/service/WebServiceTest.java
@@ -28,11 +28,11 @@ public class WebServiceTest {
 
     @Test
     public void loanApproval2() throws Exception {
-    	// Send a SOAP request and verify the SOAP reply is what we expected
+        // Send a SOAP request and verify the SOAP reply is what we expected
         httpMixIn.postResourceAndTestXML(
-        		"http://localhost:18001/loanService",
-        		"/xml/soap-loanreq2.xml",
-        		"/xml/soap-loanresp2.xml");
+                "http://localhost:18001/loanService",
+                "/xml/soap-loanreq2.xml",
+                "/xml/soap-loanresp2.xml");
     }
 
 }

--- a/bpel-service/loan_approval/src/test/resources/xml/xml-loanreq1.xml
+++ b/bpel-service/loan_approval/src/test/resources/xml/xml-loanreq1.xml
@@ -1,0 +1,5 @@
+<ns1:request xmlns:ns1="http://example.com/loan-approval/loanService/">
+   <ns1:firstName>Fred</ns1:firstName>
+   <ns1:name>Bloggs</ns1:name>
+   <ns1:amount>100</ns1:amount>
+</ns1:request>

--- a/bpel-service/loan_approval/src/test/resources/xml/xml-loanreq2.xml
+++ b/bpel-service/loan_approval/src/test/resources/xml/xml-loanreq2.xml
@@ -1,0 +1,5 @@
+<ns1:request xmlns:ns1="http://example.com/loan-approval/loanService/">
+   <ns1:firstName>Fred</ns1:firstName>
+   <ns1:name>Bloggs</ns1:name>
+   <ns1:amount>11000</ns1:amount>
+</ns1:request>

--- a/bpel-service/loan_approval/src/test/resources/xml/xml-loanresp1.xml
+++ b/bpel-service/loan_approval/src/test/resources/xml/xml-loanresp1.xml
@@ -1,0 +1,3 @@
+<requestResponse xmlns="http://example.com/loan-approval/loanService/">
+  <tns:accept xmlns:tns="http://example.com/loan-approval/loanService/">yes</tns:accept>
+</requestResponse>

--- a/bpel-service/loan_approval/src/test/resources/xml/xml-riskreq1.xml
+++ b/bpel-service/loan_approval/src/test/resources/xml/xml-riskreq1.xml
@@ -1,0 +1,5 @@
+<ns1:check xmlns:ns1="http://example.com/loan-approval/riskAssessment/">
+   <ns1:firstName>Fred</ns1:firstName>
+   <ns1:name>Bloggs</ns1:name>
+   <ns1:amount>100</ns1:amount>
+</ns1:check>

--- a/bpel-service/loan_approval/src/test/resources/xml/xml-riskreq2.xml
+++ b/bpel-service/loan_approval/src/test/resources/xml/xml-riskreq2.xml
@@ -1,0 +1,5 @@
+<ns1:check xmlns:ns1="http://example.com/loan-approval/riskAssessment/">
+   <ns1:firstName>Fred</ns1:firstName>
+   <ns1:name>Bloggs</ns1:name>
+   <ns1:amount>11000</ns1:amount>
+</ns1:check>

--- a/bpel-service/loan_approval/src/test/resources/xml/xml-riskresp1.xml
+++ b/bpel-service/loan_approval/src/test/resources/xml/xml-riskresp1.xml
@@ -1,0 +1,3 @@
+<checkResponse xmlns="http://example.com/loan-approval/riskAssessment/">
+  <tns:level xmlns:tns="http://example.com/loan-approval/loanService/">low</tns:level>
+</checkResponse>

--- a/bpel-service/say_hello/src/test/java/org/switchyard/quickstarts/bpel/service/SayHelloTest.java
+++ b/bpel-service/say_hello/src/test/java/org/switchyard/quickstarts/bpel/service/SayHelloTest.java
@@ -1,0 +1,52 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2010-2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more 
+ * details. You should have received a copy of the GNU Lesser General Public 
+ * License, v.2.1 along with this distribution; if not, write to the Free 
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  
+ * 02110-1301, USA.
+ */
+
+package org.switchyard.quickstarts.bpel.service;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+import org.switchyard.test.SwitchYardTestKit;
+
+@RunWith(SwitchYardRunner.class)
+@SwitchYardTestCaseConfig(
+        config = SwitchYardTestCaseConfig.SWITCHYARD_XML,
+        mixins = CDIMixIn.class)
+public class SayHelloTest {
+    
+    @ServiceOperation("SayHelloService")
+    private Invoker sayHello;
+    
+    private SwitchYardTestKit testKit;
+    
+    @Test
+    public void testHello() throws Exception {
+        String requestTxt = testKit.readResourceString("xml/xml-request.xml");
+        String replyTxt = testKit.readResourceString("xml/xml-response.xml");
+        
+        String replyMsg = sayHello.sendInOut(requestTxt).getContent(String.class);
+        Assert.assertEquals(replyTxt, replyMsg);
+    }
+    
+}

--- a/bpel-service/say_hello/src/test/java/org/switchyard/quickstarts/bpel/service/WebServiceTest.java
+++ b/bpel-service/say_hello/src/test/java/org/switchyard/quickstarts/bpel/service/WebServiceTest.java
@@ -19,10 +19,10 @@ public class WebServiceTest {
 
     @Test
     public void sayHello() throws Exception {
-    	// Send a SOAP request and verify the SOAP reply is what we expected
+        // Send a SOAP request and verify the SOAP reply is what we expected
         httpMixIn.postResourceAndTestXML(
-        		"http://localhost:18001/SayHelloService",
-        		"/xml/soap-request.xml",
-        		"/xml/soap-response.xml");
+                "http://localhost:18001/SayHelloService",
+                "/xml/soap-request.xml",
+                "/xml/soap-response.xml");
     }
 }

--- a/bpel-service/say_hello/src/test/resources/xml/xml-request.xml
+++ b/bpel-service/say_hello/src/test/resources/xml/xml-request.xml
@@ -1,0 +1,3 @@
+<exam:sayHello xmlns:exam="http://www.jboss.org/bpel/examples">
+    <exam:input>Fred</exam:input>
+</exam:sayHello>

--- a/bpel-service/say_hello/src/test/resources/xml/xml-response.xml
+++ b/bpel-service/say_hello/src/test/resources/xml/xml-response.xml
@@ -1,0 +1,3 @@
+<sayHelloResponse xmlns="http://www.jboss.org/bpel/examples">
+  <tns:result xmlns:tns="http://www.jboss.org/bpel/examples">Hello Fred</tns:result>
+</sayHelloResponse>

--- a/bpel-service/simple_correlation/src/main/resources/HelloGoodbye.bpel
+++ b/bpel-service/simple_correlation/src/main/resources/HelloGoodbye.bpel
@@ -63,12 +63,12 @@
       <assign name="assignHelloMesg">
           <copy>
               <from><literal><helloMessage xmlns="http://www.jboss.org/bpel/examples/simple_correlation/" >
-	<sessionId>
-	  <id></id>
-	</sessionId>
-	<parameter></parameter>
-	</helloMessage>
-	</literal></from>
+  <sessionId>
+    <id></id>
+  </sessionId>
+  <parameter></parameter>
+</helloMessage>
+</literal></from>
               <to variable="helloResponse" part="parameters" />
           </copy>
 
@@ -115,12 +115,12 @@
       <assign name="assignGoodbyeMesg">
           <copy>
               <from><literal><goodbyeMessage xmlns="http://www.jboss.org/bpel/examples/simple_correlation/" >
-	<sessionId>
-	  <id></id>
-	</sessionId>
-	<parameter></parameter>
-	</goodbyeMessage>
-	</literal></from>
+  <sessionId>
+    <id></id>
+  </sessionId>
+  <parameter></parameter>
+</goodbyeMessage>
+</literal></from>
               <to variable="goodbyeResponse" part="parameters" />
           </copy>
 

--- a/bpel-service/simple_correlation/src/test/java/org/switchyard/quickstarts/bpel/service/HelloGoodbyeTest.java
+++ b/bpel-service/simple_correlation/src/test/java/org/switchyard/quickstarts/bpel/service/HelloGoodbyeTest.java
@@ -1,0 +1,61 @@
+/* 
+ * JBoss, Home of Professional Open Source 
+ * Copyright 2010-2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved. 
+ * See the copyright.txt in the distribution for a 
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use, 
+ * modify, copy, or redistribute it subject to the terms and conditions 
+ * of the GNU Lesser General Public License, v. 2.1. 
+ * This program is distributed in the hope that it will be useful, but WITHOUT A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more 
+ * details. You should have received a copy of the GNU Lesser General Public 
+ * License, v.2.1 along with this distribution; if not, write to the Free 
+ * Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  
+ * 02110-1301, USA.
+ */
+
+package org.switchyard.quickstarts.bpel.service;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+import org.switchyard.test.Invoker;
+import org.switchyard.test.ServiceOperation;
+import org.switchyard.test.SwitchYardRunner;
+import org.switchyard.test.SwitchYardTestCaseConfig;
+import org.switchyard.test.SwitchYardTestKit;
+
+@RunWith(SwitchYardRunner.class)
+@SwitchYardTestCaseConfig(
+        config = SwitchYardTestCaseConfig.SWITCHYARD_XML,
+        mixins = {CDIMixIn.class})
+public class HelloGoodbyeTest {
+    
+    @ServiceOperation("simpleCorrelationService.hello")
+    private Invoker correlationHello;
+    
+    @ServiceOperation("simpleCorrelationService.goodbye")
+    private Invoker correlationGoodbye;
+
+    private SwitchYardTestKit testKit;
+    
+    @Test
+    public void testHelloGoodbye() throws Exception {
+        String requestTxt = testKit.readResourceString("xml/xml-hello_request1.xml");
+        String replyTxt = testKit.readResourceString("xml/xml-hello_response1.xml");
+        
+        String replyMsg = correlationHello.sendInOut(requestTxt).getContent(String.class);
+        Assert.assertEquals(replyTxt, replyMsg);
+
+        requestTxt = testKit.readResourceString("xml/xml-goodbye_request1.xml");
+        replyTxt = testKit.readResourceString("xml/xml-goodbye_response1.xml");
+        
+        replyMsg = correlationGoodbye.sendInOut(requestTxt).getContent(String.class);
+        Assert.assertEquals(replyTxt, replyMsg);
+    }
+    
+}

--- a/bpel-service/simple_correlation/src/test/resources/xml/goodbye_response1.xml
+++ b/bpel-service/simple_correlation/src/test/resources/xml/goodbye_response1.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body><goodbyeMessage xmlns="http://www.jboss.org/bpel/examples/simple_correlation/">
-	<sessionId>
-	  <id>1</id>
-	</sessionId>
-	<parameter>BPEL, Goodbye World!</parameter>
-	</goodbyeMessage></SOAP-ENV:Body></SOAP-ENV:Envelope>
+  <sessionId>
+    <id>1</id>
+  </sessionId>
+  <parameter>BPEL, Goodbye World!</parameter>
+</goodbyeMessage></SOAP-ENV:Body></SOAP-ENV:Envelope>

--- a/bpel-service/simple_correlation/src/test/resources/xml/hello_response1.xml
+++ b/bpel-service/simple_correlation/src/test/resources/xml/hello_response1.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Body><helloMessage xmlns="http://www.jboss.org/bpel/examples/simple_correlation/">
-	<sessionId>
-	  <id>1</id>
-	</sessionId>
-	<parameter>BPEL, Hello World!</parameter>
-	</helloMessage></SOAP-ENV:Body></SOAP-ENV:Envelope>
+  <sessionId>
+    <id>1</id>
+  </sessionId>
+  <parameter>BPEL, Hello World!</parameter>
+</helloMessage></SOAP-ENV:Body></SOAP-ENV:Envelope>

--- a/bpel-service/simple_correlation/src/test/resources/xml/xml-goodbye_request1.xml
+++ b/bpel-service/simple_correlation/src/test/resources/xml/xml-goodbye_request1.xml
@@ -1,0 +1,6 @@
+<goodbyeMessage xmlns="http://www.jboss.org/bpel/examples/simple_correlation/">
+  <sessionId>
+    <id>1</id>
+  </sessionId>
+  <parameter>BPEL</parameter>
+</goodbyeMessage>

--- a/bpel-service/simple_correlation/src/test/resources/xml/xml-goodbye_response1.xml
+++ b/bpel-service/simple_correlation/src/test/resources/xml/xml-goodbye_response1.xml
@@ -1,0 +1,6 @@
+<goodbyeMessage xmlns="http://www.jboss.org/bpel/examples/simple_correlation/">
+  <sessionId>
+      <id>1</id>
+  </sessionId>
+  <parameter>BPEL, Goodbye World!</parameter>
+</goodbyeMessage>

--- a/bpel-service/simple_correlation/src/test/resources/xml/xml-hello_request1.xml
+++ b/bpel-service/simple_correlation/src/test/resources/xml/xml-hello_request1.xml
@@ -1,0 +1,6 @@
+<helloMessage xmlns="http://www.jboss.org/bpel/examples/simple_correlation/">
+  <sessionId>
+    <id>1</id>
+  </sessionId>
+  <parameter>BPEL</parameter>
+</helloMessage>

--- a/bpel-service/simple_correlation/src/test/resources/xml/xml-hello_response1.xml
+++ b/bpel-service/simple_correlation/src/test/resources/xml/xml-hello_response1.xml
@@ -1,0 +1,6 @@
+<helloMessage xmlns="http://www.jboss.org/bpel/examples/simple_correlation/">
+  <sessionId>
+      <id>1</id>
+  </sessionId>
+  <parameter>BPEL, Hello World!</parameter>
+</helloMessage>


### PR DESCRIPTION
added BPEL service unit tests to:
- say_hello
- jms_binding
- loan_approval
- simple_correlation

I think that's all since xts_subordinate_wsba and xts_wsat seem to need XTS enabled on AS7 to invoke the BPEL service.
