### PR TITLE
SWITCHYARD-325: Allow developer-defined correlationId to refer to BPM processes in addition to processInstanceId

### DIFF
--- a/bpm-service/src/main/resources/META-INF/ProcessOrder.bpmn
+++ b/bpm-service/src/main/resources/META-INF/ProcessOrder.bpmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:g="http://www.jboss.org/drools/flow/gpd" xmlns:tns="http://www.jboss.org/drools" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="Definition" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.jboss.org/drools" typeLanguage="http://www.java.com/javaTypes">
-  <itemDefinition id="_contentInputItem"/>
-  <itemDefinition id="_contentOutputItem"/>
+  <itemDefinition id="_contentInputItem" structureRef="org.switchyard.quickstarts.bpm.service.data.Order"/>
+  <itemDefinition id="_contentOutputItem" structureRef="Boolean"/>
   <itemDefinition id="_messageIdItem" structureRef="String"/>
   <itemDefinition id="_userNameItem" structureRef="String"/>
   <process id="ProcessOrder" tns:packageName="org.switchyard.demo.openshift" name="ProcessOrder" isExecutable="true" processType="Private">

--- a/demos/helpdesk-webapp/src/main/resources/META-INF/persistence.xml
+++ b/demos/helpdesk-webapp/src/main/resources/META-INF/persistence.xml
@@ -8,8 +8,11 @@
     <provider>org.hibernate.ejb.HibernatePersistence</provider>
     <jta-data-source>java:jboss/datasources/jbpmDS</jta-data-source>
     <mapping-file>JBPMorm-JPA2.xml</mapping-file>
-    <class>org.drools.persistence.info.SessionInfo</class>
+    <class>org.jbpm.persistence.correlation.CorrelationKeyInfo</class>
+    <class>org.jbpm.persistence.correlation.CorrelationPropertyInfo</class>
+    <class>org.jbpm.persistence.processinstance.ProcessInstanceEventInfo</class>
     <class>org.jbpm.persistence.processinstance.ProcessInstanceInfo</class>
+    <class>org.drools.persistence.info.SessionInfo</class>
     <class>org.drools.persistence.info.WorkItemInfo</class>
     <class>org.jbpm.process.audit.ProcessInstanceLog</class>
     <class>org.jbpm.process.audit.NodeInstanceLog</class>

--- a/rules-interview-container/src/main/resources/META-INF/kmodule.xml
+++ b/rules-interview-container/src/main/resources/META-INF/kmodule.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <kmodule xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://jboss.org/kie/6.0.0/kmodule">
     <kbase name="org.switchyard.quickstarts.rules.interview">
-        <ksession name="rules-interview-container"/>
+        <ksession name="rules-interview-container" type="stateless"/>
     </kbase>
 </kmodule>


### PR DESCRIPTION
SWITCHYARD-325: Allow developer-defined correlationId to refer to BPM processes in addition to processInstanceId
https://issues.jboss.org/browse/SWITCHYARD-325
