### PR TITLE
SWITCHYARD-1572 Dead link in the Readme.md of JCA quickstart

### DIFF
--- a/bean-service/Readme.md
+++ b/bean-service/Readme.md
@@ -57,4 +57,4 @@ JBoss AS 7
 
 ## Further Reading
 
-1. [Bean Service Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Bean+Services)
+1. [Bean Service Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Bean)

--- a/bpel-service/Readme.md
+++ b/bpel-service/Readme.md
@@ -116,4 +116,4 @@ Expected Output
 
 ## Further Reading
 
-1. [BPEL Service Documentation](https://docs.jboss.org/author/display/SWITCHYARD/BPEL+Services)
+1. [BPEL Service Documentation](https://docs.jboss.org/author/display/SWITCHYARD/BPEL)

--- a/bpm-service/Readme.md
+++ b/bpm-service/Readme.md
@@ -78,4 +78,4 @@ Additionally, you can see how a domain property (userName) is retrieved from a s
 
 ## Further Reading
 
-1. [BPM Service Documentation](https://docs.jboss.org/author/display/SWITCHYARD/BPM+Services)
+1. [BPM Service Documentation](https://docs.jboss.org/author/display/SWITCHYARD/BPM)

--- a/camel-amqp-binding/Readme.md
+++ b/camel-amqp-binding/Readme.md
@@ -18,4 +18,4 @@ JBoss AS 7
 
 ## Further Reading
 
-1. [Camel Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel+Bindings)
+1. [AMQP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/AMQP)

--- a/camel-binding/Readme.md
+++ b/camel-binding/Readme.md
@@ -37,4 +37,4 @@ Hello there Captain Crunch :-)
 
 ## Further Reading
 
-1. [Camel Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel+Bindings)
+1. [File Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/File)

--- a/camel-ftp-binding/Readme.md
+++ b/camel-ftp-binding/Readme.md
@@ -36,4 +36,4 @@ JBoss AS 7
 
 ## Further Reading
 
-1. [Camel Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel+Bindings)
+1. [FTP FTPS SFTP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/FTP+FTPS+SFTP)

--- a/camel-jaxb/Readme.md
+++ b/camel-jaxb/Readme.md
@@ -50,5 +50,5 @@ Received response
 
 ## Further Reading
 
-1. [Camel Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel+Bindings)
+1. [Camel Service Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel)
 2. [Camel Data Formats](http://camel.apache.org/data-format.html)

--- a/camel-jms-binding/Readme.md
+++ b/camel-jms-binding/Readme.md
@@ -39,4 +39,4 @@ JBoss AS 7
 
 ## Further Reading
 
-1. [Camel Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel+Bindings)
+1. [JMS Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/JMS)

--- a/camel-jpa-binding/Readme.md
+++ b/camel-jpa-binding/Readme.md
@@ -38,4 +38,4 @@ JBoss AS 7
 
 ## Further Reading
 
-1. [Camel Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel+Bindings)
+1. [JPA Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/JPA)

--- a/camel-mail-binding/Readme.md
+++ b/camel-mail-binding/Readme.md
@@ -42,4 +42,4 @@ JBoss AS 7
 
 ## Further Reading
 
-1. [Camel Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel+Bindings)
+1. [Mail Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Mail)

--- a/camel-netty-binding/Readme.md
+++ b/camel-netty-binding/Readme.md
@@ -54,4 +54,4 @@ To test TCP you will need few additional steps. Stop server if it's running.
 
 ## Further Reading
 
-1. [Camel Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel+Bindings)
+1. [TCP UDP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/TCP+UDP)

--- a/camel-quartz-binding/Readme.md
+++ b/camel-quartz-binding/Readme.md
@@ -25,4 +25,4 @@ JBoss AS 7
 
 ## Further Reading
 
-1. [Camel Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel+Bindings)
+1. [Quartz Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Quartz)

--- a/camel-service/Readme.md
+++ b/camel-service/Readme.md
@@ -55,5 +55,5 @@ sally: Actually, any kind of dairy is OK in my book
 
 ## Further Reading
 
-1. [Camel Service Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel+Services)
+1. [Camel Service Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel)
 

--- a/camel-soap-proxy/Readme.md
+++ b/camel-soap-proxy/Readme.md
@@ -54,4 +54,5 @@ Expected Output:
 
 ## Further Reading
 
-1. [Camel Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel+Bindings)
+1. [Camel Service Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel)
+2. [SOAP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/SOAP)

--- a/camel-sql-binding/Readme.md
+++ b/camel-sql-binding/Readme.md
@@ -41,4 +41,4 @@ JBoss AS 7
 
 ## Further Reading
 
-1. [Camel Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel+Bindings)
+1. [SQL Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/SQL)

--- a/demos/helpdesk/Readme.md
+++ b/demos/helpdesk/Readme.md
@@ -69,6 +69,6 @@ INFO  [org.switchyard.quickstarts.demos.helpdesk.TicketManagementServiceBean] (h
 ## Further Reading
 
 1. [Configuration Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Configuration)
-2. [SOAP Bindings Documentation](https://docs.jboss.org/author/display/SWITCHYARD/SOAP+Bindings)
-3. [BPM Services Documentation](https://docs.jboss.org/author/display/SWITCHYARD/BPM+Services)
-4. [Bean Services Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Bean+Services)
+2. [SOAP Bindings Documentation](https://docs.jboss.org/author/display/SWITCHYARD/SOAP)
+3. [BPM Services Documentation](https://docs.jboss.org/author/display/SWITCHYARD/BPM)
+4. [Bean Services Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Bean)

--- a/demos/orders/README.md
+++ b/demos/orders/README.md
@@ -33,5 +33,5 @@ This example demonstrates how to:
 ## Further Reading
 
 1. [SwitchYard User Documentation](https://docs.jboss.org/author/display/SWITCHYARD/)
-2. [SwitchYard CDI Bean Services](https://docs.jboss.org/author/display/SWITCHYARD/Bean+Services)
-3. [SwitchYard SOAP Bindings](https://docs.jboss.org/author/display/SWITCHYARD/SOAP+Bindings)
+2. [SwitchYard CDI Bean Services](https://docs.jboss.org/author/display/SWITCHYARD/Bean)
+3. [SwitchYard SOAP Bindings](https://docs.jboss.org/author/display/SWITCHYARD/SOAP)

--- a/http-binding/Readme.md
+++ b/http-binding/Readme.md
@@ -40,4 +40,4 @@ JBoss AS 7
 
 ## Further Reading
 
-1. [HTTP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/HTTP+Bindings)
+1. [HTTP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/HTTP)

--- a/jca-inflow-activemq/Readme.md
+++ b/jca-inflow-activemq/Readme.md
@@ -47,4 +47,4 @@ Expected Results
 
 ## Further Reading
 
-1. [JCA Bindings Documentation](https://docs.jboss.org/author/display/SWITCHYARD/JCA+Bindings)
+1. [JCA Bindings Documentation](https://docs.jboss.org/author/display/SWITCHYARD/JCA)

--- a/jca-inflow-hornetq/Readme.md
+++ b/jca-inflow-hornetq/Readme.md
@@ -49,4 +49,4 @@ Expected Results
 
 ## Further Reading
 
-1. [HornetQ Bindings Documentation](https://docs.jboss.org/author/display/SWITCHYARD/JCA+Bindings)
+1. [HornetQ Bindings Documentation](https://docs.jboss.org/author/display/SWITCHYARD/JCA)

--- a/jca-outbound-activemq/Readme.md
+++ b/jca-outbound-activemq/Readme.md
@@ -53,4 +53,4 @@ Expected Results
 
 ## Further Reading
 
-1. [JCA Bindings Documentation](https://docs.jboss.org/author/display/SWITCHYARD/JCA+Bindings)
+1. [JCA Bindings Documentation](https://docs.jboss.org/author/display/SWITCHYARD/JCA)

--- a/jca-outbound-hornetq/Readme.md
+++ b/jca-outbound-hornetq/Readme.md
@@ -55,4 +55,4 @@ Expected Results
 
 ## Further Reading
 
-1. [HornetQ Bindings Documentation](https://docs.jboss.org/author/display/SWITCHYARD/JCA+Bindings)
+1. [JCA Bindings Documentation](https://docs.jboss.org/author/display/SWITCHYARD/JCA)

--- a/remote-invoker/Readme.md
+++ b/remote-invoker/Readme.md
@@ -41,3 +41,4 @@ You should see the following in the command output:
 ## Further Reading
 
 1. [Remote Invoker Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Remote+Invoker)
+2. [SCA Bindings Documentation](https://docs.jboss.org/author/display/SWITCHYARD/SCA)

--- a/rest-binding/Readme.md
+++ b/rest-binding/Readme.md
@@ -79,4 +79,4 @@ JBoss AS 7
 
 ## Further Reading
 
-1. [RESTEasy Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/RESTEasy+Bindings)
+1. [RESTEasy Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/RESTEasy)

--- a/rules-camel-cbr/Readme.md
+++ b/rules-camel-cbr/Readme.md
@@ -47,6 +47,6 @@ Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.312 sec
 ## Further Reading
 
 1. [Configuration Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Configuration)
-2. [Rules Services Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Rules+Services)
-3. [Camel Services Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel+Services)
-4. [Bean Services Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Bean+Services)
+2. [Rules Services Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Rules)
+3. [Camel Services Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Camel)
+4. [Bean Services Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Bean)

--- a/rules-interview-container/Readme.md
+++ b/rules-interview-container/Readme.md
@@ -44,4 +44,4 @@ Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.131 sec`
 ## Further Reading
 
 1. [Configuration Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Configuration)
-
+2. [Rules Service Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Rules)

--- a/rules-interview/Readme.md
+++ b/rules-interview/Readme.md
@@ -40,3 +40,4 @@ Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.131 sec`
 ## Further Reading
 
 1. [Configuration Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Configuration)
+2. [Rules Service Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Rules)

--- a/soap-addressing/Readme.md
+++ b/soap-addressing/Readme.md
@@ -62,5 +62,5 @@ Order Boeing with quantity 10 accepted.
 
 ## Further Reading
 
-1. [SOAP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/SOAP+Bindings)
+1. [SOAP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/SOAP)
 2. [WS-Addressing] http://www.w3.org/standards/techs/wsaddr#w3c_all

--- a/soap-attachment/Readme.md
+++ b/soap-attachment/Readme.md
@@ -46,5 +46,5 @@ Response attachment: <external-switchyard.png> with content type image/png
 
 ## Further Reading
 
-1. [SOAP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/SOAP+Bindings)
+1. [SOAP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/SOAP)
 2. [SOAP Messages with Attachments] http://www.w3.org/TR/SOAP-attachments

--- a/soap-binding-rpc/Readme.md
+++ b/soap-binding-rpc/Readme.md
@@ -49,4 +49,4 @@ JBoss AS 7
 
 ## Further Reading
 
-1. [SOAP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/SOAP+Bindings)
+1. [SOAP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/SOAP)

--- a/soap-mtom/Readme.md
+++ b/soap-mtom/Readme.md
@@ -44,6 +44,6 @@ BufferedImage@xxxxx: type = 5 ColorModel: #pixelBits = 24 numComponents = 3 colo
 ```
 ## Further Reading
 
-1. [SOAP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/SOAP+Bindings)
+1. [SOAP Binding Documentation](https://docs.jboss.org/author/display/SWITCHYARD/SOAP)
 2. [SOAP Message Transmission Optimization Mechanism (MTOM)] http://www.w3.org/TR/soap12-mtom/
 3. [XML-binary Optimized Packaging (XOP)] http://www.w3.org/TR/xop10/

--- a/transform-jaxb/Readme.md
+++ b/transform-jaxb/Readme.md
@@ -54,3 +54,4 @@ Expected Output:
 ## Further Reading
 
 1. [Transformation Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Transformation)
+2. [JAXB Transformer Documentation](https://docs.jboss.org/author/display/SWITCHYARD/JAXB+Transformer)

--- a/transform-json/Readme.md
+++ b/transform-json/Readme.md
@@ -26,3 +26,4 @@ Running the quickstart
 ## Further Reading
 
 1. [Transformation Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Transformation)
+2. [JSON Transformer Documentation](https://docs.jboss.org/author/display/SWITCHYARD/JSON+Transformer)

--- a/transform-smooks/Readme.md
+++ b/transform-smooks/Readme.md
@@ -37,3 +37,4 @@ JBoss AS 7
 ## Further Reading
 
 1. [Transformation Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Transformation)
+2. [Smooks Transformer Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Smooks+Transformer)

--- a/transform-xslt/Readme.md
+++ b/transform-xslt/Readme.md
@@ -57,3 +57,4 @@ Expected Output
 ## Further Reading
 
 1. [Transformation Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Transformation)
+2. [XSLT Transformer Documentation](https://docs.jboss.org/author/display/SWITCHYARD/XSLT+Transformer)

--- a/validate-xml/Readme.md
+++ b/validate-xml/Readme.md
@@ -77,3 +77,4 @@ response when you disable the validator in switchyard.xml.
 ## Further Reading
 
 1. [Validation Documentation](https://docs.jboss.org/author/display/SWITCHYARD/Validation)
+2. [XML Validator Documentation](https://docs.jboss.org/author/display/SWITCHYARD/XML+Validator)


### PR DESCRIPTION
Many of the doc URLs linked from quickstarts Readme.md are dead since doc was restructured.
