### PR TITLE
SWITCHYARD-1593: Debug listener sub-packages missing in Readme's and example config

### DIFF
--- a/bpm-service/src/main/resources/META-INF/switchyard.xml
+++ b/bpm-service/src/main/resources/META-INF/switchyard.xml
@@ -13,7 +13,7 @@
             <implementation.bpm xmlns="urn:switchyard-component-bpm:config:1.0" processId="ProcessOrder">
                 <!--
                 <listeners>
-                    <listener class="org.drools.event.DebugProcessEventListener"/>
+                    <listener class="org.drools.core.event.DebugProcessEventListener"/>
                 </listeners>
                 -->
                 <manifest>

--- a/rules-camel-cbr/Readme.md
+++ b/rules-camel-cbr/Readme.md
@@ -9,8 +9,8 @@ If you would like to watch the rules execution, add these lines in
 src/main/resources/META-INF/switchyard.xml:
 ```
 <listeners>
-    <listener class="org.kie.event.rule.DebugAgendaEventListener"/>
-    <listener class="org.kie.event.rule.DebugWorkingMemoryEventListener"/>
+    <listener class="org.kie.api.event.rule.DebugAgendaEventListener"/>
+    <listener class="org.kie.api.event.rule.DebugWorkingMemoryEventListener"/>
 </listeners>
 ```
 


### PR DESCRIPTION
SWITCHYARD-1593: Debug listener sub-packages missing in Readme's and example config
https://issues.jboss.org/browse/SWITCHYARD-1593
