### PR TITLE
SWITCHYARD-1652 - Removing unused camel-route capability to eliminate SY

### DIFF
--- a/validate-xml/pom.xml
+++ b/validate-xml/pom.xml
@@ -41,10 +41,6 @@
             <artifactId>switchyard-component-soap</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.switchyard.components</groupId>
-            <artifactId>switchyard-component-camel</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.switchyard</groupId>
             <artifactId>switchyard-test</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
project warning
