### PR TITLE
SWITCHYARD-1653 - Remove unused camel route capability to eliminate

### DIFF
--- a/transform-xslt/pom.xml
+++ b/transform-xslt/pom.xml
@@ -44,10 +44,6 @@
             <artifactId>switchyard-component-soap</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.switchyard.components</groupId>
-            <artifactId>switchyard-component-camel</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.switchyard</groupId>
             <artifactId>switchyard-test</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
warning upon maven project import in tooling
