### PR TITLE
SWITCHYARD-1697: Upgrade Drools/jBPM to 6.0.0.CR3

### DIFF
--- a/bpm-service/Readme.md
+++ b/bpm-service/Readme.md
@@ -8,7 +8,7 @@ using an MVEL expression, and printed out via a BPMN onEntry-script of the Inven
 
 This example is invoked through a SOAP gateway binding.
 
-If you would like to watch the process execution, uncomment these lines in
+If you would like to log the process execution, uncomment these lines in
 src/main/resources/META-INF/switchyard.xml:
 ```
 <listeners>

--- a/rules-camel-cbr/Readme.md
+++ b/rules-camel-cbr/Readme.md
@@ -5,7 +5,7 @@ This quickstart also demonstrates the ability to use MVEL expressions to extract
 The drl resource is specified using annotations within the DestinationServiceRules interface, and checks the id of Widgets to determine the destination to set on their Boxes.
 Then, a Camel route looks at the destination set on the Box for each Widget, and routes it to the appropriate service (RedService, GreenService, or BlueService).
 
-If you would like to watch the rules execution, add these lines in
+If you would like to watch the rules execution, uncomment these lines in
 src/main/resources/META-INF/switchyard.xml:
 ```
 <listeners>

--- a/rules-camel-cbr/src/main/resources/META-INF/switchyard.xml
+++ b/rules-camel-cbr/src/main/resources/META-INF/switchyard.xml
@@ -22,6 +22,12 @@
         </component>
         <component name="DestinationService">
             <implementation.rules xmlns="urn:switchyard-component-rules:config:1.0">
+                <!--
+                <listeners>
+                    <listener class="org.kie.api.event.rule.DebugAgendaEventListener"/>
+                    <listener class="org.kie.api.event.rule.DebugWorkingMemoryEventListener"/>
+                </listeners>
+                -->
                 <manifest>
                     <resources>
                         <resource location="/META-INF/DestinationServiceRules.drl" type="DRL"/>


### PR DESCRIPTION
SWITCHYARD-1697: Upgrade Drools/jBPM to 6.0.0.CR3
https://issues.jboss.org/browse/SWITCHYARD-1697
