### PR TITLE
SWITCHYARD-1773 Some quickstarts fail tests when running mvn jboss-as:deploy

### DIFF
--- a/camel-jaxb/src/test/java/org/switchyard/quickstarts/camel/jaxb/JAXBCamelTest.java
+++ b/camel-jaxb/src/test/java/org/switchyard/quickstarts/camel/jaxb/JAXBCamelTest.java
@@ -17,6 +17,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.switchyard.component.test.mixins.http.HTTPMixIn;
+import org.switchyard.test.BeforeDeploy;
 import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 
@@ -30,10 +31,15 @@ import org.switchyard.test.SwitchYardTestCaseConfig;
 @RunWith(SwitchYardRunner.class)
 public class JAXBCamelTest {
 
-    private static final String BASE_URL = "http://localhost:8080/camel-binding";
+    private static final String BASE_URL = "http://localhost:8081/camel-binding";
 
     private HTTPMixIn http;
 
+    @BeforeDeploy
+    public void setProperties() {
+        System.setProperty("org.switchyard.component.http.standalone.port", "8081");
+    }
+    
     @Test
     public void httpJAXBCamelEndpoint() throws Exception {
         GreetingRequest request = new GreetingRequest("Magesh");

--- a/camel-soap-proxy/src/main/resources/META-INF/switchyard.xml
+++ b/camel-soap-proxy/src/main/resources/META-INF/switchyard.xml
@@ -6,13 +6,14 @@
         <soap:contextMapper/>
         <soap:wsdl>META-INF/ReverseService.wsdl</soap:wsdl>
         <soap:contextPath>proxy</soap:contextPath>
+        <soap:socketAddr>:${jettyPort}</soap:socketAddr>
       </soap:binding.soap>
     </sca:service>
     <sca:reference name="ReverseService" multiplicity="0..1" promote="ProxyService/ReverseService">
       <soap:binding.soap>
         <soap:contextMapper/>
         <soap:wsdl>META-INF/ReverseService.wsdl</soap:wsdl>
-        <soap:endpointAddress>http://localhost:8080/ReverseService</soap:endpointAddress>
+        <soap:endpointAddress>http://localhost:${jettyPort}/ReverseService</soap:endpointAddress>
       </soap:binding.soap>
     </sca:reference>
     <sca:component name="ProxyService">
@@ -27,4 +28,9 @@
       </sca:reference>
     </sca:component>
   </sca:composite>
+  <domain>
+    <properties>
+      <property name="jettyPort" value="${org.switchyard.component.http.standalone.port:8080}"/>
+    </properties>
+  </domain>
 </switchyard>

--- a/camel-soap-proxy/src/test/java/org/switchyard/quickstarts/camel/soap/proxy/CamelSOAPProxyTest.java
+++ b/camel-soap-proxy/src/test/java/org/switchyard/quickstarts/camel/soap/proxy/CamelSOAPProxyTest.java
@@ -19,6 +19,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.switchyard.test.BeforeDeploy;
 import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.component.test.mixins.http.HTTPMixIn;
@@ -34,11 +35,16 @@ import org.switchyard.transform.config.model.TransformSwitchYardScanner;
         mixins = {HTTPMixIn.class})
 public class CamelSOAPProxyTest {
 
-    private static final String WEB_SERVICE = "http://localhost:8080/ReverseService";
-    private static final String PROXY_SERVICE = "http://localhost:8080/proxy/ReverseService";
+    private static final String WEB_SERVICE = "http://localhost:8081/ReverseService";
+    private static final String PROXY_SERVICE = "http://localhost:8081/proxy/ReverseService";
 
     private HTTPMixIn _http;
     private Endpoint _endpoint;
+
+    @BeforeDeploy
+    public void setProperties() {
+        System.setProperty("org.switchyard.component.http.standalone.port", "8081");
+    }
 
     @Before
     public void startWebService() throws Exception {

--- a/http-binding/src/test/java/org/switchyard/quickstarts/http/binding/HttpBindingTest.java
+++ b/http-binding/src/test/java/org/switchyard/quickstarts/http/binding/HttpBindingTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.switchyard.component.test.mixins.cdi.CDIMixIn;
 import org.switchyard.component.test.mixins.http.HTTPMixIn;
+import org.switchyard.test.BeforeDeploy;
 import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.transform.config.model.TransformSwitchYardScanner;
@@ -36,10 +37,15 @@ import org.switchyard.transform.config.model.TransformSwitchYardScanner;
 @RunWith(SwitchYardRunner.class)
 public class HttpBindingTest {
 
-    private static final String BASE_URL = "http://localhost:8080/http-binding";
+    private static final String BASE_URL = "http://localhost:8081/http-binding";
 
     private HTTPMixIn http;
-
+    
+    @BeforeDeploy
+    public void setProperties() {
+        System.setProperty("org.switchyard.component.http.standalone.port", "8081");
+    }
+    
     /**
      * Ignore until this is fixed http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=7189193
      */

--- a/rest-binding/src/main/resources/META-INF/switchyard.xml
+++ b/rest-binding/src/main/resources/META-INF/switchyard.xml
@@ -17,7 +17,7 @@
             <rest:binding.rest xmlns:rest="urn:switchyard-component-resteasy:config:1.0">
                 <rest:messageComposer class="org.switchyard.quickstarts.rest.binding.CustomComposer"/>
                 <rest:interfaces>org.switchyard.quickstarts.rest.binding.WarehouseResource</rest:interfaces>
-                <rest:contextPath>rest-binding</rest:contextPath>
+                <rest:address>http://localhost:${restPort}</rest:address>
             </rest:binding.rest>
         </sca:reference>
         <component name="OrderService">
@@ -36,4 +36,9 @@
             </service>
         </component>
     </composite>
+    <domain>
+        <properties>
+            <property name="restPort" value="${org.switchyard.component.resteasy.standalone.port:8080}"/>
+        </properties>
+    </domain>
 </switchyard>

--- a/rest-binding/src/test/java/org/switchyard/quickstarts/rest/binding/RESTEasyBindingTest.java
+++ b/rest-binding/src/test/java/org/switchyard/quickstarts/rest/binding/RESTEasyBindingTest.java
@@ -18,6 +18,7 @@ package org.switchyard.quickstarts.rest.binding;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.switchyard.test.BeforeDeploy;
 import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.test.SwitchYardTestKit;
@@ -41,6 +42,11 @@ public class RESTEasyBindingTest {
 
     private HTTPMixIn http;
 
+    @BeforeDeploy
+    public void setProperties() {
+        System.setProperty("org.switchyard.component.resteasy.standalone.port", "8081");
+    }
+    
     /**
      * This Quickstart test exclusively uses Netty server due to buggy JDK HttpServer.
      * See https://issues.jboss.org/browse/RESTEASY-734
@@ -99,12 +105,12 @@ public class RESTEasyBindingTest {
         Assert.assertEquals(SUCCESS, response);
     }
 
-    private static String BASE_URL = "http://localhost:8080/rest-binding";
+    private static String BASE_URL = "http://localhost:8081/rest-binding";
 
     static {
         if (ResourcePublisherFactory.ignoreContext()) {
-            // Context paths are irrelevent for NettyJaxrs server
-            BASE_URL = "http://localhost:8080";
+            // Context paths are irrelevant for NettyJaxrs server
+            BASE_URL = "http://localhost:8081";
         }
     }
 

--- a/soap-addressing/src/main/java/org/switchyard/quickstarts/soap/addressing/OrderProcessor.java
+++ b/soap-addressing/src/main/java/org/switchyard/quickstarts/soap/addressing/OrderProcessor.java
@@ -37,6 +37,11 @@ public class OrderProcessor implements Processor {
 
     @Override
     public void process(Exchange exchange) throws Exception {
+    	String socketAddr = System.getProperty("org.switchyard.component.http.standalone.port");
+    	if (socketAddr==null) {
+    		socketAddr = "8080";
+    	}
+    	
         Order order = exchange.getIn().getBody(Order.class);
         System.out.println("Received Order " + order.getItem() + " with quantity " + order.getQuantity() + ".");
         Map<String, Object> headers = exchange.getIn().getHeaders();
@@ -50,11 +55,11 @@ public class OrderProcessor implements Processor {
             messageId = (SOAPHeaderElement)exchange.getIn().getHeaders().get("{http://www.w3.org/2005/08/addressing}messageid");
         }
         String replyToStr = "<wsa:ReplyTo xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">"
-                            + "<wsa:Address>http://localhost:8080/soap-addressing/client/ResponseService</wsa:Address>"
+                            + "<wsa:Address>http://localhost:" + socketAddr + "/soap-addressing/client/ResponseService</wsa:Address>"
                             + "</wsa:ReplyTo>";
         Element replyTo = XMLHelper.getDocumentFromString(replyToStr).getDocumentElement();
         String faultToStr = "<wsa:FaultTo xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">"
-                            + "<wsa:Address>http://localhost:8080/soap-addressing/fault/FaultService</wsa:Address>"
+                            + "<wsa:Address>http://localhost:" + socketAddr + "/soap-addressing/fault/FaultService</wsa:Address>"
                             + "</wsa:FaultTo>";
         Element faultTo = XMLHelper.getDocumentFromString(faultToStr).getDocumentElement();
         String relatesToStr = "<wsa:RelatesTo xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">"

--- a/soap-addressing/src/main/resources/META-INF/switchyard.xml
+++ b/soap-addressing/src/main/resources/META-INF/switchyard.xml
@@ -13,6 +13,7 @@
         <soap:contextMapper includes=".*" includeNamespaces="http://www.w3.org/2005/08/addressing" soapHeadersType="DOM"/>
         <soap:wsdl>OrderService.wsdl</soap:wsdl>
         <soap:contextPath>soap-addressing/order</soap:contextPath>
+        <soap:socketAddr>:${jettyPort}</soap:socketAddr>
       </soap:binding.soap>
     </sca:service>
 
@@ -22,7 +23,7 @@
         <!-- Will be set by the Addressing handler  -->
         <!--<soap:contextMapper includes=".*" includeNamespaces="http://www.w3.org/2005/08/addressing" soapHeadersType="DOM"/>-->
         <soap:wsdl>WarehouseService.wsdl</soap:wsdl>
-        <soap:endpointAddress>http://localhost:8080/soap-addressing/warehouse/WarehouseService</soap:endpointAddress>
+        <soap:endpointAddress>http://localhost:${jettyPort}/soap-addressing/warehouse/WarehouseService</soap:endpointAddress>
       </soap:binding.soap>
     </sca:reference>
 
@@ -44,6 +45,7 @@
         <soap:contextMapper includes=".*" includeNamespaces="http://www.w3.org/2005/08/addressing" soapHeadersType="DOM"/>
         <soap:wsdl>WarehouseService.wsdl</soap:wsdl>
         <soap:contextPath>soap-addressing/warehouse</soap:contextPath>
+        <soap:socketAddr>:${jettyPort}</soap:socketAddr>
       </soap:binding.soap>
     </sca:service>
 
@@ -54,7 +56,7 @@
         <!-- <soap:contextMapper includes=".*" includeNamespaces="http://www.w3.org/2005/08/addressing" soapHeadersType="DOM"/> -->
         <soap:wsdl>ResponseService.wsdl</soap:wsdl>
         <!-- Will be set by To header -->
-        <!-- <soap:endpointAddress>http://localhost:8080/soap-addressing/client/ResponseService</soap:endpointAddress> -->
+        <!-- <soap:endpointAddress>http://localhost:${jettyPort}/soap-addressing/client/ResponseService</soap:endpointAddress> -->
       </soap:binding.soap>
     </sca:reference>
 
@@ -65,7 +67,7 @@
         <!-- <soap:contextMapper includes=".*" includeNamespaces="http://www.w3.org/2005/08/addressing" soapHeadersType="DOM"/> -->
         <soap:wsdl>FaultService.wsdl</soap:wsdl>
         <!-- Will be set by To header -->
-        <!-- <soap:endpointAddress>http://localhost:8080/soap-addressing/fault/FaultService</soap:endpointAddress> -->
+        <!-- <soap:endpointAddress>http://localhost:${jettyPort}/soap-addressing/fault/FaultService</soap:endpointAddress> -->
       </soap:binding.soap>
     </sca:reference>
 
@@ -90,6 +92,7 @@
         <soap:contextMapper includes=".*" includeNamespaces="http://www.w3.org/2005/08/addressing" soapHeadersType="DOM"/>
         <soap:wsdl>ResponseService.wsdl</soap:wsdl>
         <soap:contextPath>soap-addressing/client</soap:contextPath>
+        <soap:socketAddr>:${jettyPort}</soap:socketAddr>
       </soap:binding.soap>
     </sca:service>
 
@@ -122,6 +125,7 @@
         <soap:contextMapper includes=".*" includeNamespaces="http://www.w3.org/2005/08/addressing" soapHeadersType="DOM"/>
         <soap:wsdl>FaultService.wsdl</soap:wsdl>
         <soap:contextPath>soap-addressing/fault</soap:contextPath>
+        <soap:socketAddr>:${jettyPort}</soap:socketAddr>
       </soap:binding.soap>
     </sca:service>
 
@@ -155,4 +159,9 @@
     <xform:transform.jaxb from="java:org.switchyard.quickstarts.soap.addressing.OrderResponse" to="{urn:switchyard-quickstart:soap-addressing:1.0}orderResponse"/>
     <xform:transform.jaxb from="{urn:switchyard-quickstart:soap-addressing:1.0}orderResponse" to="java:org.switchyard.quickstarts.soap.addressing.OrderResponse"/>
   </transforms>
+  <domain>
+    <properties>
+      <property name="jettyPort" value="${org.switchyard.component.http.standalone.port:8080}"/>
+    </properties>
+  </domain>
 </switchyard>

--- a/soap-addressing/src/test/java/org/switchyard/quickstarts/soap/addressing/SoapAddressingClient.java
+++ b/soap-addressing/src/test/java/org/switchyard/quickstarts/soap/addressing/SoapAddressingClient.java
@@ -51,13 +51,13 @@ public class SoapAddressingClient {
             System.out.println("Usage: SoapAddressingClient <item> <quantity>");
             return;
         } else {
-            SOAPUtil.prettyPrint(sendMessage(args[0], args[1]), System.out);
+            SOAPUtil.prettyPrint(sendMessage(args[0], args[1], SWITCHYARD_WEB_SERVICE), System.out);
             System.out.println();
             System.out.println(getFileMessage());
         }
     }
 
-    public static String sendMessage(String item, String quantity) throws Exception {
+    public static String sendMessage(String item, String quantity, String switchyard_web_service) throws Exception {
         File testFile = getFile();
         if (testFile.exists()) {
             testFile.delete();
@@ -65,7 +65,7 @@ public class SoapAddressingClient {
         String command =  null;
         HTTPMixIn http = new HTTPMixIn();
         http.initialize();
-        return http.postString(SWITCHYARD_WEB_SERVICE, String.format(SOAP_TEMPLATE, item, quantity));
+        return http.postString(switchyard_web_service, String.format(SOAP_TEMPLATE, item, quantity));
     }
 
     public static String getFileMessage() throws Exception {
@@ -75,7 +75,7 @@ public class SoapAddressingClient {
         while (!testFile.exists()) {
             Thread.sleep(100);
             timeout += 100;
-            if (timeout == 5000) {
+            if (timeout == 20000) {
                 break;
             }
         }

--- a/soap-addressing/src/test/java/org/switchyard/quickstarts/soap/addressing/SoapAddressingTest.java
+++ b/soap-addressing/src/test/java/org/switchyard/quickstarts/soap/addressing/SoapAddressingTest.java
@@ -14,13 +14,6 @@
 
 package org.switchyard.quickstarts.soap.addressing;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-
-import javax.xml.soap.SOAPMessage;
-import javax.xml.ws.Endpoint;
-
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -28,6 +21,7 @@ import org.junit.runner.RunWith;
 import org.switchyard.component.bean.config.model.BeanSwitchYardScanner;
 import org.switchyard.component.test.mixins.cdi.CDIMixIn;
 import org.switchyard.component.test.mixins.http.HTTPMixIn;
+import org.switchyard.test.BeforeDeploy;
 import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.transform.config.model.TransformSwitchYardScanner;
@@ -39,9 +33,14 @@ import org.switchyard.transform.config.model.TransformSwitchYardScanner;
         scanners = {BeanSwitchYardScanner.class, TransformSwitchYardScanner.class })
 public class SoapAddressingTest {
 
-    private static final String SWITCHYARD_WEB_SERVICE = "http://localhost:8080/soap-addressing/order/OrderService";
+    private static final String SWITCHYARD_WEB_SERVICE = "http://localhost:8081/soap-addressing/order/OrderService";
 
     private HTTPMixIn _httpMixIn;
+
+    @BeforeDeploy
+    public void setProperties() {
+        System.setProperty("org.switchyard.component.http.standalone.port", "8081");
+    }
 
     @Test
     public void testSwitchYardWebService() throws Exception {
@@ -52,7 +51,7 @@ public class SoapAddressingTest {
 
     @Test
     public void fault() throws Exception {
-        String response = SoapAddressingClient.sendMessage("Airbus", "3");
+        String response = SoapAddressingClient.sendMessage("Airbus", "3", SWITCHYARD_WEB_SERVICE);
         org.switchyard.component.soap.util.SOAPUtil.prettyPrint(response, System.out);
         Assert.assertTrue(response.contains("<RelatesTo xmlns=\"http://www.w3.org/2005/08/addressing\">uuid:3d3fcbbb-fd43-4118-b40e-62577894f39a</RelatesTo>"));
         // Fault detail is not generated due to HandlerException?
@@ -61,7 +60,7 @@ public class SoapAddressingTest {
 
     @Test
     public void wsAddressingReplyTo() throws Exception {
-        String response = SoapAddressingClient.sendMessage("Boeing", "10");
+        String response = SoapAddressingClient.sendMessage("Boeing", "10", SWITCHYARD_WEB_SERVICE);
         Assert.assertTrue(response.contains("urn:switchyard-quickstart:soap-addressing:1.0:OrderService:orderResponse"));
         Assert.assertTrue(response.contains("uuid:3d3fcbbb-fd43-4118-b40e-62577894f39a"));
         Assert.assertTrue(response.contains("Thank you for your order. You should hear back from our WarehouseService shortly!"));
@@ -76,7 +75,7 @@ public class SoapAddressingTest {
     @Ignore
     @Test
     public void wsAddressingFaultTo() throws Exception {
-        String response = SoapAddressingClient.sendMessage("Guardian Angel", "3");
+        String response = SoapAddressingClient.sendMessage("Guardian Angel", "3", SWITCHYARD_WEB_SERVICE);
         Assert.assertTrue(response.contains("Thank you for your order. You should hear back from our WarehouseService shortly!"));
 
         String text = SoapAddressingClient.getFileMessage();

--- a/soap-addressing/src/test/resources/xml/soap-request-faultto.xml
+++ b/soap-addressing/src/test/resources/xml/soap-request-faultto.xml
@@ -6,7 +6,7 @@
         <wsa:MessageID>uuid:3d3fcbbb-fd43-4118-b40e-62577894f39a</wsa:MessageID>
         <wsa:Action>urn:switchyard-quickstart:soap-addressing:1.0:OrderService:orderRequest</wsa:Action>
         <wsa:FaultTo>
-             <wsa:Address>http://localhost:8080/soap-addressing/fault/FaultService</wsa:Address>
+             <wsa:Address>http://localhost:8081/soap-addressing/fault/FaultService</wsa:Address>
         </wsa:FaultTo>
     </soapenv:Header>
    <soapenv:Body>

--- a/soap-addressing/src/test/resources/xml/soap-request-replyto.xml
+++ b/soap-addressing/src/test/resources/xml/soap-request-replyto.xml
@@ -6,7 +6,7 @@
         <wsa:MessageID>uuid:3d3fcbbb-fd43-4118-b40e-62577894f39a</wsa:MessageID>
         <wsa:Action>urn:switchyard-quickstart:soap-addressing:1.0:OrderService:orderRequest</wsa:Action>
         <wsa:ReplyTo>
-             <wsa:Address>http://localhost:8080/soap-addressing/client/ResponseService</wsa:Address>
+             <wsa:Address>http://localhost:8081/soap-addressing/client/ResponseService</wsa:Address>
         </wsa:ReplyTo>
     </soapenv:Header>
    <soapenv:Body>

--- a/soap-attachment/src/main/resources/META-INF/switchyard.xml
+++ b/soap-attachment/src/main/resources/META-INF/switchyard.xml
@@ -13,6 +13,7 @@
       <soap:binding.soap>
         <soap:wsdl>ImageService.wsdl</soap:wsdl>
         <soap:contextPath>soap-attachment</soap:contextPath>
+        <soap:socketAddr>:${jettyPort}</soap:socketAddr>
       </soap:binding.soap>
     </sca:service>
     <sca:reference name="EchoImageService" multiplicity="0..1" promote="InternalEchoServiceBean/EchoImageService">
@@ -20,7 +21,7 @@
       <soap:binding.soap>
         <soap:contextMapper/>
         <soap:wsdl>ImageService-External.wsdl</soap:wsdl>
-        <soap:endpointAddress>http://localhost:8080/soap-attachment-external/ImageServiceService</soap:endpointAddress>
+        <soap:endpointAddress>http://localhost:${jettyPort}/soap-attachment-external/ImageServiceService</soap:endpointAddress>
       </soap:binding.soap>
     </sca:reference>
     <sca:component name="InternalEchoServiceBean">
@@ -41,6 +42,7 @@
         <soap:contextMapper/>
         <soap:wsdl>ImageService-External.wsdl</soap:wsdl>
         <soap:contextPath>soap-attachment-external</soap:contextPath>
+        <soap:socketAddr>:${jettyPort}</soap:socketAddr>
       </soap:binding.soap>
     </sca:service>
     <sca:component name="EchoServiceBean">
@@ -52,4 +54,9 @@
       </sca:service>
     </sca:component>
   </sca:composite>
+  <domain>
+    <properties>
+      <property name="jettyPort" value="${org.switchyard.component.http.standalone.port:8080}"/>
+    </properties>
+  </domain>
 </switchyard>

--- a/soap-attachment/src/test/java/org/switchyard/quickstarts/soap/attachment/SoapAttachmentClient.java
+++ b/soap-attachment/src/test/java/org/switchyard/quickstarts/soap/attachment/SoapAttachmentClient.java
@@ -14,9 +14,6 @@
 
 package org.switchyard.quickstarts.soap.attachment;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Iterator;
 
@@ -29,7 +26,6 @@ import javax.xml.soap.SOAPBodyElement;
 import javax.xml.soap.SOAPConnection;
 import javax.xml.soap.SOAPConnectionFactory;
 import javax.xml.soap.SOAPConstants;
-import javax.xml.soap.SOAPElement;
 import javax.xml.soap.SOAPMessage;
 
 import org.switchyard.common.type.Classes;
@@ -45,15 +41,14 @@ public class SoapAttachmentClient {
     private static final String SWITCHYARD_WEB_SERVICE = "http://localhost:8080/soap-attachment/ImageServiceService";
 
     public static void main(String[] args) throws Exception {
-        String command =  null;
-        SOAPMessage response = sendMessage();
+        SOAPMessage response = sendMessage(SWITCHYARD_WEB_SERVICE);
         SOAPUtil.prettyPrint(response, System.out);
         Iterator<AttachmentPart> iterator = response.getAttachments();
         AttachmentPart ap = iterator.next();
         System.out.println("Response attachment: " + ap.getContentId() + " with content type " + ap.getContentType());
     }
 
-    public static SOAPMessage sendMessage() throws Exception {
+    public static SOAPMessage sendMessage(String switchyard_web_service) throws Exception {
         SOAPConnectionFactory conFactory = SOAPConnectionFactory.newInstance();
 
         SOAPConnection connection = conFactory.createConnection();
@@ -67,6 +62,6 @@ public class SoapAttachmentClient {
         ap.setDataHandler(new DataHandler(new URLDataSource(imageUrl)));
         ap.setContentId("switchyard.png");
         msg.addAttachmentPart(ap);
-        return connection.call(msg, new URL(SWITCHYARD_WEB_SERVICE));
+        return connection.call(msg, new URL(switchyard_web_service));
     }
 }

--- a/soap-attachment/src/test/java/org/switchyard/quickstarts/soap/attachment/SoapAttachmentTest.java
+++ b/soap-attachment/src/test/java/org/switchyard/quickstarts/soap/attachment/SoapAttachmentTest.java
@@ -19,9 +19,9 @@ import javax.xml.soap.SOAPMessage;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.switchyard.common.type.Classes;
 import org.switchyard.component.bean.config.model.BeanSwitchYardScanner;
 import org.switchyard.component.test.mixins.cdi.CDIMixIn;
+import org.switchyard.test.BeforeDeploy;
 import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.transform.config.model.TransformSwitchYardScanner;
@@ -33,9 +33,16 @@ import org.switchyard.transform.config.model.TransformSwitchYardScanner;
         scanners = {BeanSwitchYardScanner.class, TransformSwitchYardScanner.class })
 public class SoapAttachmentTest {
 
+    private static final String SWITCHYARD_WEB_SERVICE = "http://localhost:8081/soap-attachment/ImageServiceService";
+
+    @BeforeDeploy
+    public void setProperties() {
+        System.setProperty("org.switchyard.component.http.standalone.port", "8081");
+    }
+
     @Test
     public void testSwitchYardWebService() throws Exception {
-        SOAPMessage response = SoapAttachmentClient.sendMessage();
+        SOAPMessage response = SoapAttachmentClient.sendMessage(SWITCHYARD_WEB_SERVICE);
         Assert.assertTrue(response.getAttachments().hasNext());
     }
 }

--- a/soap-binding-rpc/src/main/resources/META-INF/switchyard.xml
+++ b/soap-binding-rpc/src/main/resources/META-INF/switchyard.xml
@@ -7,6 +7,7 @@
         <soap:messageComposer class="org.switchyard.quickstarts.soap.binding.rpc.CustomComposer"/>
         <soap:wsdl>HelloWorldWS.wsdl</soap:wsdl>
         <soap:contextPath>soap-binding-rpc</soap:contextPath>
+        <soap:socketAddr>:${jettyPort}</soap:socketAddr>
       </soap:binding.soap>
     </sca:service>
     <sca:component name="InternalRouter">
@@ -26,7 +27,7 @@
         <soap:contextMapper/>
         <soap:wsdl>HelloWorldWS.wsdl</soap:wsdl>
         <soap:wsdlPort>HelloWorldPort</soap:wsdlPort>
-        <soap:endpointAddress>http://localhost:8080/external/HelloWorldWSService</soap:endpointAddress>
+        <soap:endpointAddress>http://localhost:${jettyPort}/external/HelloWorldWSService</soap:endpointAddress>
       </soap:binding.soap>
     </sca:reference>
     <sca:component name="HelloWorldServiceBean">
@@ -41,7 +42,13 @@
         <soap:contextMapper/>
         <soap:wsdl>HelloWorldWS-External.wsdl</soap:wsdl>
         <soap:contextPath>external</soap:contextPath>
+        <soap:socketAddr>:${jettyPort}</soap:socketAddr>
       </soap:binding.soap>
     </sca:service>
   </sca:composite>
+  <domain>
+    <properties>
+      <property name="jettyPort" value="${org.switchyard.component.http.standalone.port:8080}"/>
+    </properties>
+  </domain>
 </switchyard>

--- a/soap-binding-rpc/src/test/java/org/switchyard/quickstarts/soap/binding/rpc/SoapBindingTest.java
+++ b/soap-binding-rpc/src/test/java/org/switchyard/quickstarts/soap/binding/rpc/SoapBindingTest.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 import org.switchyard.component.bean.config.model.BeanSwitchYardScanner;
 import org.switchyard.component.test.mixins.cdi.CDIMixIn;
 import org.switchyard.component.test.mixins.http.HTTPMixIn;
+import org.switchyard.test.BeforeDeploy;
 import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.transform.config.model.TransformSwitchYardScanner;
@@ -33,11 +34,16 @@ import org.switchyard.transform.config.model.TransformSwitchYardScanner;
         scanners = {BeanSwitchYardScanner.class, TransformSwitchYardScanner.class })
 public class SoapBindingTest {
 
-    private static final String SWITCHYARD_WEB_SERVICE = "http://localhost:8080/soap-binding-rpc/HelloWorldWSService";
+    private static final String SWITCHYARD_WEB_SERVICE = "http://localhost:8081/soap-binding-rpc/HelloWorldWSService";
 
     private static Endpoint _endpoint;
 
     private HTTPMixIn _httpMixIn;
+
+    @BeforeDeploy
+    public void setProperties() {
+        System.setProperty("org.switchyard.component.http.standalone.port", "8081");
+    }
 
     @Test
     public void testSwitchYardWebService() throws Exception {


### PR DESCRIPTION
Changed tests to use port 8081 instead of 8080 so that they can be executed when the AS is running in the background.
