### PR TITLE
SWITCHYARD-1820 Configure jboss-as-maven-plugin to skip deploying the parent

### DIFF
--- a/demos/multiApp/README.md
+++ b/demos/multiApp/README.md
@@ -13,13 +13,23 @@ Consult the README.md in each individual project for more info.
 
 ## Running the Example
 
-1. Deploy each of the following to a SwitchYard AS7 runtime:
-    * multiApp/artifacts/target/OrderService.jar
-    * multiApp/order-service/target/switchyard-quickstart-demo-multi-order-service.jar
-    * multiApp/order-consumer/target/switchyard-quickstart-demo-multi-order-consumer.jar
-    * multiApp/web/target/switchyard-quickstart-demo-multi-web.war
-    
-2. Use one or both of the consuming application projects:
+1. Build the quickstart:
+
+        mvn clean install
+
+2. Start JBoss AS 7 in standalone-full mode:
+
+        ${AS}/bin/standalone.sh --server-config=standalone-full.xml
+
+3. Deploy JMS Queue
+
+        cp order-consumer/src/test/resources/switchyard-quickstart-demo-multi-order-consumer-hornetq-jms.xml ${AS}/standalone/deployments
+
+4. Deploy the quickstart
+
+        mvn jboss-as:deploy
+
+5. Use one or both of the consuming application projects:
     * <b>Web</b>: Visit <http://localhost:8080/switchyard-quickstart-demo-multi-web>.
     * <b>JMS</b>: Use 'mvn exec:java' in the order-consumer project to submit a JMS order message via the OrderIntake service.
 

--- a/demos/multiApp/artifacts/src/main/resources/OrderService.wsdl
+++ b/demos/multiApp/artifacts/src/main/resources/OrderService.wsdl
@@ -40,7 +40,7 @@
   
   <service name="OrderService">
     <port name="OrderServicePort" binding="tns:OrderServiceBinding">
-      <soap:address location="http://localhost:18001/quickstart-demo-multiapp/OrderService"/>
+      <soap:address location="http://localhost:8080/quickstart-demo-multiapp/OrderService"/>
     </port>
   </service>
 </definitions>

--- a/demos/multiApp/order-consumer/src/main/resources/META-INF/switchyard.xml
+++ b/demos/multiApp/order-consumer/src/main/resources/META-INF/switchyard.xml
@@ -20,7 +20,12 @@
             </reference>
         </component>
     </composite>
+    <domain>
+        <properties>
+            <property name="jettyPort" value="${org.switchyard.component.http.standalone.port:8080}"/>
+        </properties>
+    </domain>
     <artifacts>
-        <artifact name="OrderService" url="http://localhost:8080/guvnorsoa/rest/packages/OrderService"/>
+        <artifact name="OrderService" url="http://localhost:${jettyPort}/guvnorsoa/rest/packages/OrderService"/>
     </artifacts>
 </switchyard>

--- a/demos/multiApp/order-service/src/main/resources/META-INF/switchyard.xml
+++ b/demos/multiApp/order-service/src/main/resources/META-INF/switchyard.xml
@@ -4,7 +4,7 @@
             <interface.wsdl interface="OrderService.wsdl#wsdl.porttype(OrderService)"/>
             <binding.soap xmlns="urn:switchyard-component-soap:config:1.0">
                 <wsdl>OrderService.wsdl</wsdl>
-                <socketAddr>:18001</socketAddr>
+                <socketAddr>:${jettyPort}</socketAddr>
                 <contextPath>quickstart-demo-multiapp</contextPath>
             </binding.soap>
         </service>
@@ -28,7 +28,12 @@
         <transform.java xmlns="urn:switchyard-config:transform:1.0" class="org.switchyard.quickstarts.demo.multiapp.service.Transformers" from="java:org.switchyard.quickstarts.demo.multiapp.OrderAck" to="{urn:switchyard-quickstart-demo:multiapp:1.0}submitOrderResponse"/>
         <transform.java xmlns="urn:switchyard-config:transform:1.0" class="org.switchyard.quickstarts.demo.multiapp.service.Transformers" from="{urn:switchyard-quickstart-demo:multiapp:1.0}submitOrder" to="java:org.switchyard.quickstarts.demo.multiapp.Order"/>
     </transforms>
+    <domain>
+        <properties>
+            <property name="jettyPort" value="${org.switchyard.component.http.standalone.port:8080}"/>
+        </properties>
+    </domain>
     <artifacts>
-        <artifact name="OrderService" url="http://localhost:8080/guvnorsoa/rest/packages/OrderService"/>
+        <artifact name="OrderService" url="http://localhost:${jettyPort}/guvnorsoa/rest/packages/OrderService"/>
     </artifacts>
 </switchyard>

--- a/demos/multiApp/order-service/src/test/java/org/switchyard/quickstarts/demo/multiapp/service/WebServiceTest.java
+++ b/demos/multiApp/order-service/src/test/java/org/switchyard/quickstarts/demo/multiapp/service/WebServiceTest.java
@@ -16,6 +16,7 @@ package org.switchyard.quickstarts.demo.multiapp.service;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.switchyard.test.BeforeDeploy;
 import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.component.test.mixins.cdi.CDIMixIn;
@@ -31,11 +32,16 @@ public class WebServiceTest {
 
     private HTTPMixIn httpMixIn;
 
+    @BeforeDeploy
+    public void setProperties() {
+        System.setProperty("org.switchyard.component.http.standalone.port", "8081");
+    }
+
     @Test
     public void invokeOrderWebService() throws Exception {
         // Use the HttpMixIn to invoke the SOAP binding endpoint with a SOAP input (from the test classpath)
         // and compare the SOAP response to a SOAP response resource (from the test classpath)...
-        httpMixIn.postResourceAndTestXML("http://localhost:18001/quickstart-demo-multiapp/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
+        httpMixIn.postResourceAndTestXML("http://localhost:8081/quickstart-demo-multiapp/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
     }
 }
 

--- a/demos/multiApp/pom.xml
+++ b/demos/multiApp/pom.xml
@@ -30,4 +30,16 @@
         <module>order-consumer</module>
         <module>web</module>
     </modules>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.as.plugins</groupId>
+                <artifactId>jboss-as-maven-plugin</artifactId>
+                <inherited>false</inherited>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/demos/multiApp/web/src/main/resources/META-INF/switchyard.xml
+++ b/demos/multiApp/web/src/main/resources/META-INF/switchyard.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<switchyard xmlns="urn:switchyard-config:switchyard:1.0">
+<switchyard xmlns="urn:switchyard-config:switchyard:1.0" name="web" targetNamespace="urn:switchyard-quickstart-demo:multiapp:0.1.0">
     <composite xmlns="http://docs.oasis-open.org/ns/opencsa/sca/200912" name="web" targetNamespace="urn:switchyard-quickstart-demo:multiapp:0.1.0"/>
+    <domain>
+        <properties>
+            <property name="jettyPort" value="${org.switchyard.component.http.standalone.port:8080}"/>
+        </properties>
+    </domain>
     <artifacts>
-        <artifact name="OrderService" url="http://localhost:8080/guvnorsoa/rest/packages/OrderService"/>
+        <artifact name="OrderService" url="http://localhost:${jettyPort}/guvnorsoa/rest/packages/OrderService"/>
     </artifacts>
 </switchyard>


### PR DESCRIPTION
Also fixed the multiApp ports and updated the readme.
