### PR TITLE
SWITCHYARD-1950 for IN_ONLY, ClientProxyBean and camel OutboundHandler d...

### DIFF
--- a/demos/transaction-propagation/dealer/src/test/java/org/switchyard/quickstarts/demo/txpropagation/DealerTest.java
+++ b/demos/transaction-propagation/dealer/src/test/java/org/switchyard/quickstarts/demo/txpropagation/DealerTest.java
@@ -73,6 +73,7 @@ public class DealerTest {
         offer.setAmount(450.00);
 
         // configure our proxy for the service reference
+        testKit.replaceService("DealLogger");
         MockHandler creditService = testKit.replaceService("CreditCheckService");
         Application reply = new Application();
         reply.setApproved(true);


### PR DESCRIPTION
...oesn't propagate a fault to the consumer

Fixed a bug in the testcase which didn't appear without the SWITCHYARD-1950 fix
