### PR TITLE
SWITCHYARD-2091 Verify functionality of validation components in Karaf

### DIFF
--- a/validate-xml/pom.xml
+++ b/validate-xml/pom.xml
@@ -24,7 +24,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>switchyard-validate-xml</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>SwitchYard Quickstart: validate-xml</name>
     <description>Quickstart : XML Message Validation</description>
     <licenses>
@@ -38,6 +38,15 @@
         <deploy.skip>true</deploy.skip>
         <maven.compiler.target>1.6</maven.compiler.target>
         <maven.compiler.source>1.6</maven.compiler.source>
+        <switchyard.osgi.export.pkg>
+            org.switchyard.quickstarts.validate.xml*
+        </switchyard.osgi.export.pkg>
+        <switchyard.osgi.require.capability>
+            org.ops4j.pax.cdi.extension; filter:="(extension=switchyard-component-bean)",
+            org.ops4j.pax.cdi.extension; filter:="(extension=deltaspike-core-api)",
+            osgi.extender; filter:="(osgi.extender=pax.cdi)"
+        </switchyard.osgi.require.capability>
+        <switchyard.osgi.provide.capability />
     </properties>
     <dependencies>
         <dependency>

--- a/validate-xml/src/main/resources/META-INF/switchyard.xml
+++ b/validate-xml/src/main/resources/META-INF/switchyard.xml
@@ -20,7 +20,7 @@
             <interface.wsdl interface="wsdl/OrderService.wsdl#wsdl.porttype(OrderService)"/>
             <binding.soap xmlns="urn:switchyard-component-soap:config:1.0">
                 <wsdl>wsdl/OrderService.wsdl</wsdl>
-                <socketAddr>:18001</socketAddr>
+                <socketAddr>:${jettyPort}</socketAddr>
                 <contextPath>quickstart-validate-xml</contextPath>
             </binding.soap>
         </service>
@@ -32,7 +32,7 @@
         </component>
     </composite>
     <transforms>
-        <transform.xslt xmlns="urn:switchyard-config:transform:1.0" from="{urn:switchyard-quickstart:validate-xml:0.1.0}order" to="{urn:switchyard-quickstart:validate-xml:0.1.0}orderAck" xsltFile="xslt/order.xslt"/>
+        <transform.xslt xmlns="urn:switchyard-config:transform:1.0" from="{urn:switchyard-quickstart:validate-xml:0.1.0}order" to="{urn:switchyard-quickstart:validate-xml:0.1.0}orderAck" xsltFile="xslt/order.xslt" failOnWarning="false"/>
     </transforms>
     <validates>
         <validate.xml xmlns="urn:switchyard-config:validate:1.0" name="{urn:switchyard-quickstart:validate-xml:0.1.0}order" schemaType="XML_SCHEMA" namespaceAware="true">
@@ -44,4 +44,9 @@
             </schemaCatalogs>
         </validate.xml>
     </validates>
+    <domain>
+        <properties>
+            <property name="jettyPort" value="${org.switchyard.component.http.standalone.port:8080}"/>
+        </properties>
+    </domain>
 </switchyard>

--- a/validate-xml/src/test/java/org/switchyard/quickstarts/validate/xml/WebServiceTest.java
+++ b/validate-xml/src/test/java/org/switchyard/quickstarts/validate/xml/WebServiceTest.java
@@ -19,6 +19,7 @@ package org.switchyard.quickstarts.validate.xml;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.switchyard.test.BeforeDeploy;
 import org.switchyard.test.SwitchYardRunner;
 import org.switchyard.test.SwitchYardTestCaseConfig;
 import org.switchyard.component.test.mixins.cdi.CDIMixIn;
@@ -32,17 +33,22 @@ public class WebServiceTest {
 
     private HTTPMixIn httpMixIn;
 
+    @BeforeDeploy
+    public void setProperties() {
+        System.setProperty("org.switchyard.component.http.standalone.port", "8081");
+    }
+
     @Test
     public void invokeOrderWebService() throws Exception {
         httpMixIn.
-            postResourceAndTestXML("http://localhost:18001/quickstart-validate-xml/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
+            postResourceAndTestXML("http://localhost:8081/quickstart-validate-xml/OrderService", "/xml/soap-request.xml", "/xml/soap-response.xml");
     }
 
     @Test
     public void invokeOrderWebServiceValidationFail() throws Exception {
         String response = httpMixIn.
-            postResource("http://localhost:18001/quickstart-validate-xml/OrderService", "/xml/soap-request-with-invalid-element.xml");
-        Assert.assertTrue(response.contains("Invalid content was found starting with element 'invalid-element'. No child element is expected at this point."));
+            postResource("http://localhost:8081/quickstart-validate-xml/OrderService", "/xml/soap-request-with-invalid-element.xml");
+        Assert.assertTrue("Unexpected response: " + response, response.contains("1 validation error(s)") && response.contains("invalid-element"));
     }
 
     /*
@@ -51,7 +57,7 @@ public class WebServiceTest {
     @Test
     public void invokeOrderWebServiceWithInvalidElement() throws Exception {
         httpMixIn.
-            postResourceAndTestXML("http://localhost:18001/quickstart-validate-xml/OrderService", "/xml/soap-request-with-invalid-element.xml", "/xml/soap-response.xml");
+            postResourceAndTestXML("http://localhost:8081/quickstart-validate-xml/OrderService", "/xml/soap-request-with-invalid-element.xml", "/xml/soap-response.xml");
     }
      */
 }


### PR DESCRIPTION
Initial work to get validate-xml quickstart deployed on karaf. Note it still fails with SWITCHYARD-2118.
