### PR TITLE
SWITCHYARD-2060 Quickstarts should use maven-bundle-plugin to add Dependencies

### DIFF
--- a/camel-jms-binding/pom.xml
+++ b/camel-jms-binding/pom.xml
@@ -123,13 +123,13 @@
         <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Dependencies>org.jboss.as.naming</Dependencies>
-                            <Dependencies>org.hornetq</Dependencies>
+                            <Dependencies>org.hornetq, org.jboss.as.naming</Dependencies>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/demos/policy-transaction/pom.xml
+++ b/demos/policy-transaction/pom.xml
@@ -141,13 +141,13 @@
         <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
                 <configuration>
                     <archive>
                         <manifestEntries>
-                            <Dependencies>org.hornetq</Dependencies>
-                            <Dependencies>org.jboss.as.naming</Dependencies>
+                            <Dependencies>org.hornetq, org.jboss.as.naming</Dependencies>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION
Quickstarts should use maven-bundle-plugin to add Dependencies
