### PR TITLE
SWITCHYARD-2068 Verify functionality of Rules component in Karaf

### DIFF
--- a/rules-camel-cbr/pom.xml
+++ b/rules-camel-cbr/pom.xml
@@ -20,7 +20,7 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>switchyard-rules-camel-cbr</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>SwitchYard Quickstart: rules-camel-cbr</name>
     <description>Quickstart : Rules+Camel Content-Based Router</description>
     <licenses>
@@ -31,9 +31,24 @@
         </license>
     </licenses>
     <properties>
+        <deploy.skip>true</deploy.skip>
         <maven.compiler.target>1.6</maven.compiler.target>
         <maven.compiler.source>1.6</maven.compiler.source>
-        <deploy.skip>true</deploy.skip>
+        <switchyard.osgi.export.pkg>
+            org.switchyard.quickstarts.rules.camel.cbr*
+        </switchyard.osgi.export.pkg>
+        <switchyard.osgi.dynamic>
+             org.switchyard,org.switchyard.*
+        </switchyard.osgi.dynamic>
+        <switchyard.osgi.require.capability>
+            org.ops4j.pax.cdi.extension; filter:="(extension=switchyard-component-bean)",
+            org.ops4j.pax.cdi.extension; filter:="(extension=deltaspike-core-api)",
+            osgi.extender; filter:="(osgi.extender=pax.cdi)"
+        </switchyard.osgi.require.capability>
+        <switchyard.osgi.provide.capability/>
+	<switchyard.osgi.dynamic>
+            org.switchyard,org.switchyard.*
+        </switchyard.osgi.dynamic>
     </properties>
     <dependencies>
         <dependency>
@@ -60,15 +75,19 @@
         </dependency>
         <dependency>
             <groupId>org.switchyard.components</groupId>
+            <artifactId>switchyard-component-camel-file</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.switchyard.components</groupId>
             <artifactId>switchyard-component-camel</artifactId>
         </dependency>
         <dependency>
             <groupId>org.switchyard.components</groupId>
-            <artifactId>switchyard-component-rules</artifactId>
+            <artifactId>switchyard-component-camel-file</artifactId>
         </dependency>
         <dependency>
             <groupId>org.switchyard.components</groupId>
-            <artifactId>switchyard-component-sca</artifactId>
+            <artifactId>switchyard-component-rules</artifactId>
         </dependency>
         <dependency>
             <groupId>org.switchyard</groupId>

--- a/rules-interview-container/Readme.md
+++ b/rules-interview-container/Readme.md
@@ -42,6 +42,11 @@ JBoss AS 7
 ```
             mvn exec:java
 ```
+or if running in Karaf or Fuse :
+```
+            mvn exec:java -Dexec.args="18001"
+```
+
 <br/>
     - SOAP-UI : Use the wsdl for this project (src/main/resources/wsdl/OrderService.wsdl) to 
       create a soap-ui project. Use the sample request (src/test/resources/xml/soap-request-pass.xml) 

--- a/rules-interview-container/pom.xml
+++ b/rules-interview-container/pom.xml
@@ -20,6 +20,7 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>switchyard-rules-interview-container</artifactId>
+    <packaging>bundle</packaging>
     <name>SwitchYard Quickstart: rules-interview-container</name>
     <description>Quickstart : Rules Interview (Container)</description>
     <licenses>
@@ -47,6 +48,15 @@
         <deploy.skip>true</deploy.skip>
         <maven.compiler.target>1.6</maven.compiler.target>
         <maven.compiler.source>1.6</maven.compiler.source>
+        <switchyard.osgi.export.pkg>
+            org.switchyard.quickstarts.rules.interview*
+        </switchyard.osgi.export.pkg>
+        <switchyard.osgi.require.capability>
+            org.ops4j.pax.cdi.extension; filter:="(extension=switchyard-component-bean)",
+            org.ops4j.pax.cdi.extension; filter:="(extension=deltaspike-core-api)",
+            osgi.extender; filter:="(osgi.extender=pax.cdi)"
+        </switchyard.osgi.require.capability>
+        <switchyard.osgi.provide.capability/>
     </properties>
     <dependencies>
         <dependency>

--- a/rules-interview-container/src/test/java/org/switchyard/quickstarts/rules/interview/RulesInterviewClient.java
+++ b/rules-interview-container/src/test/java/org/switchyard/quickstarts/rules/interview/RulesInterviewClient.java
@@ -23,7 +23,7 @@ import org.switchyard.component.test.mixins.http.HTTPMixIn;
  */
 public final class RulesInterviewClient {
 
-    private static final String URL = "http://localhost:8080/rules-interview-container/Interview";
+    private static final String URL = "http://localhost:PORT/rules-interview-container/Interview";
     private static final String XML = "src/test/resources/xml/soap-request-pass.xml";
 
     /**
@@ -37,13 +37,20 @@ public final class RulesInterviewClient {
      * @param ignored not used.
      * @throws Exception if something goes wrong.
      */
-    public static void main(final String[] ignored) throws Exception {
+    public static void main(final String[] ports) throws Exception {
 
         HTTPMixIn soapMixIn = new HTTPMixIn();
         soapMixIn.initialize();
 
         try {
-            String result = soapMixIn.postFile(URL, XML);
+	    String urlChanged = new String();
+	    String port = "8080";
+	    if (ports.length >= 1) {
+                port = ports[0];
+	    }	
+	    urlChanged = URL.replace("PORT", port);
+            String result = soapMixIn.postFile(urlChanged, XML);
+	    System.out.println("URL : " + urlChanged);
             System.out.println("SOAP Reply:\n" + result);
         } finally {
             soapMixIn.uninitialize();

--- a/rules-interview-dtable/Readme.md
+++ b/rules-interview-dtable/Readme.md
@@ -39,6 +39,11 @@ JBoss AS 7
 ```
             mvn exec:java
 ```
+or if running in Karaf or Fuse :
+```
+            mvn exec:java -Dexec.args="18001"
+```
+
 <br/>
     - SOAP-UI : Use the wsdl for this project (src/main/resources/wsdl/OrderService.wsdl) to 
       create a soap-ui project. Use the sample request (src/test/resources/xml/soap-request-pass.xml) 

--- a/rules-interview-dtable/pom.xml
+++ b/rules-interview-dtable/pom.xml
@@ -20,6 +20,7 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>switchyard-rules-interview-dtable</artifactId>
+    <packaging>bundle</packaging>
     <name>SwitchYard Quickstart: rules-interview-dtable</name>
     <description>Quickstart : Rules Interview (Decision Table)</description>
     <licenses>
@@ -47,6 +48,15 @@
         <deploy.skip>true</deploy.skip>
         <maven.compiler.target>1.6</maven.compiler.target>
         <maven.compiler.source>1.6</maven.compiler.source>
+        <switchyard.osgi.export.pkg>
+            org.switchyard.quickstarts.rules.interview*
+        </switchyard.osgi.export.pkg>
+        <switchyard.osgi.require.capability>
+            org.ops4j.pax.cdi.extension; filter:="(extension=switchyard-component-bean)",
+            org.ops4j.pax.cdi.extension; filter:="(extension=deltaspike-core-api)",
+            osgi.extender; filter:="(osgi.extender=pax.cdi)"
+        </switchyard.osgi.require.capability>
+        <switchyard.osgi.provide.capability/>
     </properties>
     <dependencies>
         <dependency>

--- a/rules-interview-dtable/src/test/java/org/switchyard/quickstarts/rules/interview/RulesInterviewClient.java
+++ b/rules-interview-dtable/src/test/java/org/switchyard/quickstarts/rules/interview/RulesInterviewClient.java
@@ -23,7 +23,7 @@ import org.switchyard.component.test.mixins.http.HTTPMixIn;
  */
 public final class RulesInterviewClient {
 
-    private static final String URL = "http://localhost:8080/rules-interview-dtable/Interview";
+    private static final String URL = "http://localhost:PORT/rules-interview-dtable/Interview";
     private static final String XML = "src/test/resources/xml/soap-request-pass.xml";
 
     /**
@@ -37,13 +37,20 @@ public final class RulesInterviewClient {
      * @param ignored not used.
      * @throws Exception if something goes wrong.
      */
-    public static void main(final String[] ignored) throws Exception {
+    public static void main(final String[] ports) throws Exception {
 
         HTTPMixIn soapMixIn = new HTTPMixIn();
         soapMixIn.initialize();
 
         try {
-            String result = soapMixIn.postFile(URL, XML);
+	    String urlChanged = new String();
+	    String port = "8080";
+	    if (ports.length >= 1) {
+                port = ports[0];
+	    }	
+	    urlChanged = URL.replace("PORT", port);
+            String result = soapMixIn.postFile(urlChanged, XML);
+	    System.out.println("URL : " + urlChanged);
             System.out.println("SOAP Reply:\n" + result);
         } finally {
             soapMixIn.uninitialize();

--- a/rules-interview/Readme.md
+++ b/rules-interview/Readme.md
@@ -31,6 +31,7 @@ JBoss AS 7
 
         mvn install -Pdeploy
 
+
 3. Submit a webservice request to invoke the SOAP gateway.  There are a number of ways to do this :
     - Submit a request with your preferred SOAP client - src/test/resources/xml contains 
       sample requests and the responses that you should see
@@ -38,6 +39,10 @@ JBoss AS 7
 <br/>
 ```
             mvn exec:java
+```
+or if running in Karaf or Fuse :
+```
+	    mvn exec:java -Dexec.args="18001"
 ```
 <br/>
     - SOAP-UI : Use the wsdl for this project (src/main/resources/wsdl/OrderService.wsdl) to 

--- a/rules-interview/pom.xml
+++ b/rules-interview/pom.xml
@@ -20,6 +20,7 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>switchyard-rules-interview</artifactId>
+    <packaging>bundle</packaging> 
     <name>SwitchYard Quickstart: rules-interview</name>
     <description>Quickstart : Rules Interview</description>
     <licenses>
@@ -47,6 +48,15 @@
         <deploy.skip>true</deploy.skip>
         <maven.compiler.target>1.6</maven.compiler.target>
         <maven.compiler.source>1.6</maven.compiler.source>
+        <switchyard.osgi.export.pkg>
+            org.switchyard.quickstarts.rules.interview*
+        </switchyard.osgi.export.pkg>
+        <switchyard.osgi.require.capability>
+	    org.ops4j.pax.cdi.extension; filter:="(extension=switchyard-component-bean)",
+            org.ops4j.pax.cdi.extension; filter:="(extension=deltaspike-core-api)",
+            osgi.extender; filter:="(osgi.extender=pax.cdi)"
+        </switchyard.osgi.require.capability>
+        <switchyard.osgi.provide.capability/>
     </properties>
     <dependencies>
         <dependency>

--- a/rules-interview/src/test/java/org/switchyard/quickstarts/rules/interview/RulesInterviewClient.java
+++ b/rules-interview/src/test/java/org/switchyard/quickstarts/rules/interview/RulesInterviewClient.java
@@ -23,7 +23,7 @@ import org.switchyard.component.test.mixins.http.HTTPMixIn;
  */
 public final class RulesInterviewClient {
 
-    private static final String URL = "http://localhost:8080/rules-interview/Interview";
+    private static final String URL = "http://localhost:PORT/rules-interview/Interview";
     private static final String XML = "src/test/resources/xml/soap-request-pass.xml";
 
     /**
@@ -37,13 +37,20 @@ public final class RulesInterviewClient {
      * @param ignored not used.
      * @throws Exception if something goes wrong.
      */
-    public static void main(final String[] ignored) throws Exception {
+    public static void main(final String[] ports) throws Exception {
 
         HTTPMixIn soapMixIn = new HTTPMixIn();
         soapMixIn.initialize();
 
         try {
-            String result = soapMixIn.postFile(URL, XML);
+	    String urlChanged = new String();
+	    String port = "8080";
+	    if (ports.length >= 1) {
+                port = ports[0];
+	    }	
+	    urlChanged = URL.replace("PORT", port);
+            String result = soapMixIn.postFile(urlChanged, XML);
+	    System.out.println("URL : " + urlChanged);
             System.out.println("SOAP Reply:\n" + result);
         } finally {
             soapMixIn.uninitialize();


### PR DESCRIPTION
Verify functionality of Rules component in Karaf.    Change quickstarts to bundle packaging, and modify the client test classes so that they can respect the port selection that is specified in the switchyard.xml and that is used by Fuse/karaf.
