### PR TITLE
SWITCHYARD-2371 bpel-jms-binding and camel-jms-binding quickstart client...

### DIFF
--- a/bpel-jms-binding/pom.xml
+++ b/bpel-jms-binding/pom.xml
@@ -39,6 +39,7 @@
         </switchyard.osgi.dynamic>
         <version.felix.maven>2.4.0</version.felix.maven>
         <version.wildfly.maven>1.0.2.Final</version.wildfly.maven>
+        <version.wildfly.hornetq>2.4.1.Final</version.wildfly.hornetq>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -190,7 +191,67 @@
             <id>wildfly</id>
             <properties>
                 <wildfly.port>9990</wildfly.port>
+                <hornetqmixin.http.upgrade.enabled>true</hornetqmixin.http.upgrade.enabled>
+                <hornetqmixin.port>8080</hornetqmixin.port>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-core-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-commons</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-journal</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <systemProperty>
+                                    <key>hornetqmixin.port</key>
+                                    <value>8080</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>hornetqmixin.http.upgrade.enabled</key>
+                                    <value>true</value>
+                                </systemProperty>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/camel-jms-binding/pom.xml
+++ b/camel-jms-binding/pom.xml
@@ -43,6 +43,7 @@
         </switchyard.osgi.dynamic>
         <version.felix.maven>2.4.0</version.felix.maven>
         <version.wildfly.maven>1.0.2.Final</version.wildfly.maven>
+        <version.wildfly.hornetq>2.4.1.Final</version.wildfly.hornetq>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -75,26 +76,6 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-core-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-jms-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-jms-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
         </dependency>
         <dependency>
             <groupId>org.switchyard</groupId>
@@ -231,7 +212,67 @@
             <id>wildfly</id>
             <properties>
                 <wildfly.port>9990</wildfly.port>
+                <hornetqmixin.http.upgrade.enabled>true</hornetqmixin.http.upgrade.enabled>
+                <hornetqmixin.port>8080</hornetqmixin.port>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-core-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-commons</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-journal</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <systemProperty>
+                                    <key>hornetqmixin.port</key>
+                                    <value>8080</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>hornetqmixin.http.upgrade.enabled</key>
+                                    <value>true</value>
+                                </systemProperty>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/demos/multiApp/order-consumer/pom.xml
+++ b/demos/multiApp/order-consumer/pom.xml
@@ -30,7 +30,9 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
     </licenses>
-    <properties/>
+    <properties>
+        <version.wildfly.hornetq>2.4.1.Final</version.wildfly.hornetq>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.switchyard</groupId>
@@ -51,10 +53,6 @@
         <dependency>
             <groupId>org.switchyard.components</groupId>
             <artifactId>switchyard-component-soap</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-core-client</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.jms</groupId>
@@ -178,4 +176,71 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>wildfly</id>
+            <properties>
+                <hornetqmixin.http.upgrade.enabled>true</hornetqmixin.http.upgrade.enabled>
+                <hornetqmixin.port>8080</hornetqmixin.port>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-core-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-commons</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-journal</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <systemProperty>
+                                    <key>hornetqmixin.port</key>
+                                    <value>8080</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>hornetqmixin.http.upgrade.enabled</key>
+                                    <value>true</value>
+                                </systemProperty>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/demos/policy-transaction/pom.xml
+++ b/demos/policy-transaction/pom.xml
@@ -44,6 +44,7 @@
         </switchyard.osgi.dynamic>
         <version.felix.maven>2.4.0</version.felix.maven>
         <version.wildfly.maven>1.0.2.Final</version.wildfly.maven>
+        <version.wildfly.hornetq>2.4.1.Final</version.wildfly.hornetq>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -87,26 +88,6 @@
         <dependency>
             <groupId>org.jboss.spec.javax.jms</groupId>
             <artifactId>jboss-jms-api_1.1_spec</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-core-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-jms-server</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-jms-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
         </dependency>
         <dependency>
             <groupId>org.switchyard</groupId>
@@ -249,7 +230,67 @@
             <id>wildfly</id>
             <properties>
                 <wildfly.port>9990</wildfly.port>
+                <hornetqmixin.http.upgrade.enabled>true</hornetqmixin.http.upgrade.enabled>
+                <hornetqmixin.port>8080</hornetqmixin.port>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-core-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-commons</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-journal</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <systemProperty>
+                                    <key>hornetqmixin.port</key>
+                                    <value>8080</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>hornetqmixin.http.upgrade.enabled</key>
+                                    <value>true</value>
+                                </systemProperty>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/ear-deployment/order-consumer/pom.xml
+++ b/ear-deployment/order-consumer/pom.xml
@@ -29,6 +29,9 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
     </licenses>
+    <properties>
+        <version.wildfly.hornetq>2.4.1.Final</version.wildfly.hornetq>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>org.switchyard</groupId>
@@ -53,10 +56,6 @@
         <dependency>
             <groupId>org.switchyard.quickstarts</groupId>
             <artifactId>switchyard-ear-deployment-artifacts</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hornetq</groupId>
-            <artifactId>hornetq-core-client</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.jms</groupId>
@@ -143,4 +142,71 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>wildfly</id>
+            <properties>
+                <hornetqmixin.http.upgrade.enabled>true</hornetqmixin.http.upgrade.enabled>
+                <hornetqmixin.port>8080</hornetqmixin.port>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-core-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-commons</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-journal</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <systemProperty>
+                                    <key>hornetqmixin.port</key>
+                                    <value>8080</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>hornetqmixin.http.upgrade.enabled</key>
+                                    <value>true</value>
+                                </systemProperty>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/jca-inflow-hornetq/pom.xml
+++ b/jca-inflow-hornetq/pom.xml
@@ -33,6 +33,7 @@
         <maven.compiler.target>1.6</maven.compiler.target>
         <maven.compiler.source>1.6</maven.compiler.source>
         <version.wildfly.maven>1.0.2.Final</version.wildfly.maven>
+        <version.wildfly.hornetq>2.4.1.Final</version.wildfly.hornetq>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -171,7 +172,67 @@
             <id>wildfly</id>
             <properties>
                 <wildfly.port>9990</wildfly.port>
+                <hornetqmixin.http.upgrade.enabled>true</hornetqmixin.http.upgrade.enabled>
+                <hornetqmixin.port>8080</hornetqmixin.port>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-core-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-commons</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-journal</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <systemProperty>
+                                    <key>hornetqmixin.port</key>
+                                    <value>8080</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>hornetqmixin.http.upgrade.enabled</key>
+                                    <value>true</value>
+                                </systemProperty>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/jca-outbound-hornetq/pom.xml
+++ b/jca-outbound-hornetq/pom.xml
@@ -33,6 +33,7 @@
         <maven.compiler.target>1.6</maven.compiler.target>
         <maven.compiler.source>1.6</maven.compiler.source>
         <version.wildfly.maven>1.0.2.Final</version.wildfly.maven>
+        <version.wildfly.hornetq>2.4.1.Final</version.wildfly.hornetq>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -177,7 +178,67 @@
             <id>wildfly</id>
             <properties>
                 <wildfly.port>9990</wildfly.port>
+                <hornetqmixin.http.upgrade.enabled>true</hornetqmixin.http.upgrade.enabled>
+                <hornetqmixin.port>8080</hornetqmixin.port>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-core-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-client</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-jms-server</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-commons</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-journal</artifactId>
+                    <version>${version.wildfly.hornetq}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <systemProperty>
+                                    <key>hornetqmixin.port</key>
+                                    <value>8080</value>
+                                </systemProperty>
+                                <systemProperty>
+                                    <key>hornetqmixin.http.upgrade.enabled</key>
+                                    <value>true</value>
+                                </systemProperty>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
...s fail on hornetq

Added system properties to set http-upgrade-enabled to the HornetQMixIn into wildfly maven profile. Overrode HornetQ dependencies in the wildfly maven profile so that we can switch the HornetQ client version to which support http upgrade connection. Tested on both of EAP without -Pwildfly and WildFly with -Pwildfly.
