### PR TITLE
SWITCHYARD-2488: Upgrade KIE/Drools/jBPM from 6.2.0.Beta3 to 6.2.0.CR3

### DIFF
--- a/demos/helpdesk/pom.xml
+++ b/demos/helpdesk/pom.xml
@@ -100,7 +100,7 @@
         <version.enforcer.maven>1.3.1</version.enforcer.maven>
         <version.felix.maven>2.4.0</version.felix.maven>
         <version.wildfly.maven>1.0.2.Final</version.wildfly.maven>
-        <version.org.jbpm>6.2.0.Beta3</version.org.jbpm>
+        <version.org.jbpm>6.2.0.CR3</version.org.jbpm>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/demos/library/src/main/resources/META-INF/switchyard.xml
+++ b/demos/library/src/main/resources/META-INF/switchyard.xml
@@ -73,7 +73,7 @@
               <bpm:output from="loanResponse" to="message.content"/>
             </bpm:outputs>
           </bpm:operation>
-          <bpm:operation name="returnRequest" type="SIGNAL_EVENT" eventId="Signal_1">
+          <bpm:operation name="returnRequest" type="SIGNAL_EVENT" eventId="ReturnSignal">
             <bpm:outputs>
               <bpm:output from="returnResponse" to="message.content"/>
             </bpm:outputs>


### PR DESCRIPTION
SWITCHYARD-2488: Upgrade KIE/Drools/jBPM from 6.2.0.Beta3 to 6.2.0.CR3
https://issues.jboss.org/browse/SWITCHYARD-2488
