### PR TITLE
SWITCHYARD-2555 -Pdeploy for jca-{in,out}-activemq qs is broken

### DIFF
--- a/jca-inflow-activemq/Readme.md
+++ b/jca-inflow-activemq/Readme.md
@@ -23,19 +23,27 @@ EAP
 
         ${AS}/bin/standalone.sh --server-config standalone-full.xml
 
-3. Build and deploy the quickstart
+3. Deploy ActiveMQ resource adapter
+
+        mvn install -Pdeploy-rar
+
+4. Restart EAP instance to reflect resource adapter configuration
+
+5. Build and deploy the quickstart
 
         mvn install -Pdeploy
 
-4. Execute ActiveMQClient
+6. Execute ActiveMQClient
 
         mvn exec:java
 
-5. Check the server console for output from the service.
+7. Check the server console for output from the service.
 
-6. Undeploy the quickstart:
+8. Undeploy the quickstart and resource adapter:
 
         mvn clean -Pdeploy
+
+9. Shutdown EAP instance (previous step removes resource adapter configuration, but is not reflected until shutdown)
 
 
 Wildfly
@@ -46,19 +54,27 @@ Wildfly
 
         ${AS}/bin/standalone.sh -server-config standalone-full.xml
 
-3. Build and deploy the quickstart
+3. Deploy ActiveMQ resource adapter
+
+        mvn install -Pdeploy-rar -Pwildfly
+
+4. Restart wildfly instance to reflect resource adapter configuration
+
+5. Build and deploy the quickstart
 
         mvn install -Pdeploy -Pwildfly
 
-4. Execute ActiveMQClient
+6. Execute ActiveMQClient
 
         mvn exec:java
 
-5. Check the server console for output from the service.
+7. Check the server console for output from the service.
 
-6. Undeploy the quickstart:
+8. Undeploy the quickstart and resource adapter:
 
         mvn clean -Pdeploy -Pwildfly
+
+9. Shutdown wildfly instance (previous step removes resource adapter configuration, but is not reflected until shutdown)
 
 
 Karaf

--- a/jca-inflow-activemq/config.cli
+++ b/jca-inflow-activemq/config.cli
@@ -1,8 +1,10 @@
 if (outcome != success) of /subsystem=resource-adapters/resource-adapter=activemq-ra.rar:read-resource
     /subsystem=resource-adapters/resource-adapter=activemq-ra.rar:add(archive=activemq-ra.rar)
+    /subsystem=resource-adapters/resource-adapter=activemq-ra.rar:write-attribute(name="transaction-support",value="XATransaction")
     /subsystem=resource-adapters/resource-adapter=activemq-ra.rar/connection-definitions=QueueConnectionFactory:add(class-name="org.apache.activemq.ra.ActiveMQManagedConnectionFactory", jndi-name="java:/AMQJmsXA")
     /subsystem=resource-adapters/resource-adapter=activemq-ra.rar/connection-definitions=QueueConnectionFactory/config-properties=ServerUrl:add(value="tcp://127.0.0.1:61616")
     /subsystem=resource-adapters/resource-adapter=activemq-ra.rar/admin-objects=JCAInflowGreetingServiceQueue:add(class-name="org.apache.activemq.command.ActiveMQQueue", jndi-name="java:/JCAInflowGreetingServiceQueue")
     /subsystem=resource-adapters/resource-adapter=activemq-ra.rar/admin-objects=JCAInflowGreetingServiceQueue/config-properties=PhysicalName:add(value="JCAInflowGreetingServiceQueue")
-    :reload
+# https://github.com/wildfly/wildfly-maven-plugin/issues/21 - reload breaks connection
+#    :reload
 end-if

--- a/jca-inflow-activemq/pom.xml
+++ b/jca-inflow-activemq/pom.xml
@@ -43,6 +43,7 @@
     </licenses>
     <properties>
         <skipTests>true</skipTests>
+        <deploy-rar.skip>true</deploy-rar.skip>
         <deploy.skip>true</deploy.skip>
         <wildfly.port>9999</wildfly.port>
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -167,7 +168,7 @@
                                     <script>config.cli</script>
                                 </scripts>
                             </afterDeployment>
-                            <skip>${deploy.skip}</skip>
+                            <skip>${deploy-rar.skip}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -256,6 +257,12 @@
             <id>deploy</id>
             <properties>
                 <deploy.skip>false</deploy.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>deploy-rar</id>
+            <properties>
+                <deploy-rar.skip>false</deploy-rar.skip>
             </properties>
         </profile>
         <profile>

--- a/jca-outbound-activemq/Readme.md
+++ b/jca-outbound-activemq/Readme.md
@@ -17,19 +17,27 @@ EAP
 
         ${AS}/bin/standalone.sh --server-config standalone-full.xml
 
-3. Build and deploy the quickstart
+3. Deploy ActiveMQ resource adapter
+
+        mvn install -Pdeploy-rar
+
+4. Restart EAP instance to reflect resource adapter configuration
+
+5. Build and deploy the quickstart
 
         mvn install -Pdeploy
 
-4. Execute ActiveMQClient
+6. Execute ActiveMQClient
 
         mvn exec:java
 
-5. Check the output from the client.
+7. Check the output from the client.
 
-6. Undeploy the quickstart:
+8. Undeploy the quickstart and resource adapter:
 
         mvn clean -Pdeploy
+
+9. Shutdown EAP instance (previous step removes resource adapter configuration, but is not reflected until shutdown)
 
 
 Wildfly
@@ -40,19 +48,27 @@ Wildfly
 
         ${AS}/bin/standalone.sh -server-config standalone-full.xml
 
-3. Build and deploy the quickstart
+3. Deploy ActiveMQ resource adapter
+
+        mvn install -Pdeploy-rar -Pwildfly
+
+4. Restart wildfly instance to reflect resource adapter configuration
+
+5. Build and deploy the quickstart
 
         mvn install -Pdeploy -Pwildfly
 
-4. Execute ActiveMQClient
+6. Execute ActiveMQClient
 
         mvn exec:java
 
-5. Check the output from the client.
+7. Check the output from the client.
 
-6. Undeploy the quickstart:
+8. Undeploy the quickstart and resource adapter:
 
         mvn clean -Pdeploy -Pwildfly
+
+9. Shutdown wildfly instance (previous step removes resource adapter configuration, but is not reflected until shutdown)
 
 
 Karaf

--- a/jca-outbound-activemq/config.cli
+++ b/jca-outbound-activemq/config.cli
@@ -1,5 +1,6 @@
 if (outcome != success) of /subsystem=resource-adapters/resource-adapter=activemq-ra.rar:read-resource
     /subsystem=resource-adapters/resource-adapter=activemq-ra.rar:add(archive=activemq-ra.rar)
+    /subsystem=resource-adapters/resource-adapter=activemq-ra.rar:write-attribute(name="transaction-support",value="XATransaction")
     /subsystem=resource-adapters/resource-adapter=activemq-ra.rar/connection-definitions=QueueConnectionFactory:add(class-name="org.apache.activemq.ra.ActiveMQManagedConnectionFactory", jndi-name="java:/AMQJmsXA")
     /subsystem=resource-adapters/resource-adapter=activemq-ra.rar/connection-definitions=QueueConnectionFactory/config-properties=ServerUrl:add(value="tcp://127.0.0.1:61616")
     /subsystem=resource-adapters/resource-adapter=activemq-ra.rar/admin-objects=OrderQueue:add(class-name="org.apache.activemq.command.ActiveMQQueue", jndi-name="java:/OrderQueue")
@@ -8,5 +9,6 @@ if (outcome != success) of /subsystem=resource-adapters/resource-adapter=activem
     /subsystem=resource-adapters/resource-adapter=activemq-ra.rar/admin-objects=ShippingQueue/config-properties=PhysicalName:add(value="ShippingQueue")
     /subsystem=resource-adapters/resource-adapter=activemq-ra.rar/admin-objects=FillingStockQueue:add(class-name="org.apache.activemq.command.ActiveMQQueue", jndi-name="java:/FillingStockQueue")
     /subsystem=resource-adapters/resource-adapter=activemq-ra.rar/admin-objects=FillingStockQueue/config-properties=PhysicalName:add(value="FillingStockQueue")
-    :reload
+# https://github.com/wildfly/wildfly-maven-plugin/issues/21 - reload breaks connection
+#    :reload
 end-if

--- a/jca-outbound-activemq/pom.xml
+++ b/jca-outbound-activemq/pom.xml
@@ -43,6 +43,7 @@
     </licenses>
     <properties>
         <skipTests>true</skipTests>
+        <deploy-rar.skip>true</deploy-rar.skip>
         <deploy.skip>true</deploy.skip>
         <wildfly.port>9999</wildfly.port>
         <maven.compiler.target>1.6</maven.compiler.target>
@@ -149,7 +150,7 @@
                                     <script>config.cli</script>
                                 </scripts>
                             </afterDeployment>
-                            <skip>${deploy.skip}</skip>
+                            <skip>${deploy-rar.skip}</skip>
                         </configuration>
                     </execution>
                     <execution>
@@ -244,6 +245,12 @@
             <id>deploy</id>
             <properties>
                 <deploy.skip>false</deploy.skip>
+            </properties>
+        </profile>
+        <profile>
+            <id>deploy-rar</id>
+            <properties>
+                <deploy-rar.skip>false</deploy-rar.skip>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
Removed ":reload" command from CLI script and added an insturction to restart EAP/WildFly instance after RAR deploy.