### PR TITLE
SWITCHYARD-2533 camel-netty-quickstart specifies karaf profile but does not contain one

### DIFF
--- a/camel-netty-binding/Readme.md
+++ b/camel-netty-binding/Readme.md
@@ -105,7 +105,7 @@ karaf@root> features:install switchyard-quickstart-camel-netty-binding
 5. Execute client and send text message :
 <br/>
 ```
-mvn exec:java -Pudp -Pkaraf
+mvn exec:java -Pudp
 ```
 <br/>
 


### PR DESCRIPTION
Remove the karaf profile use from the README.