### PR TITLE
SWITCHYARD-2645 org.switchyard.test.quickstarts.HttpBindingQuickstartTes...

### DIFF
--- a/http-binding/src/test/java/org/switchyard/quickstarts/http/binding/HttpBindingTest.java
+++ b/http-binding/src/test/java/org/switchyard/quickstarts/http/binding/HttpBindingTest.java
@@ -79,7 +79,7 @@ public class HttpBindingTest {
     @Test
     public void headers() throws Exception {
         String response = http.sendString(BASE_URL + "/symbol", "headers", HTTPMixIn.HTTP_POST);
-        Assert.assertTrue(response.indexOf("Content-type=text/xml; charset=UTF-8") > 0);
+        Assert.assertTrue("Unexpected response: [" + response + "]", response.indexOf("Content-type=text/xml; charset=UTF-8") >= 0);
     }
 
     @Test


### PR DESCRIPTION
...t failing on Wildfly

Assertion fails if Content-type is the first header in response, as indexOf() returns 0
